### PR TITLE
Upgrade library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,158 +24,48 @@ matrix:
         - COVERAGE='true'
         - COMPOSER_FLAGS='--prefer-lowest'
 
-    # Doctrine bridge
     - php: '7.0'
-      env:
-        - COVERAGE='true'
-        - DOCTRINE_VERSION='~2.5.0'
-        - COMPOSER_FLAGS='--prefer-lowest'
-
+      env: SYMFONY_VERSION='~2.7.0'
     - php: '7.0'
-      env:
-        - DOCTRINE_VERSION='~2.5.0'
-
-    # Eloquent bridge
-    - php: '7.0'
-      env:
-        - COVERAGE='true'
-        - ELOQUENT_VERSION='~5.3.0'
-        - COMPOSER_FLAGS='--prefer-lowest'
-    - php: '7.0'
-      env:
-        - ELOQUENT_VERSION='~5.3.0'
-
-    # Symfony bridge
-    - php: '7.0'
-      env:
-        - COVERAGE='true'
-        - SYMFONY_VERSION='~3.0.0'
-        - COMPOSER_FLAGS='--prefer-lowest'
+      env: SYMFONY_VERSION='~2.8.0'
     - php: '7.0'
       env: SYMFONY_VERSION='~3.1.0'
     - php: '7.0'
       env: SYMFONY_VERSION='~3.2.0@dev'
 
-    # Symfony bridge with Doctrine
-    - php: '7.0'
-      env:
-        - COVERAGE='true'
-        - DOCTRINE_VERSION='~2.5.0'
-        - SYMFONY_VERSION='~3.0.0'
-        - COMPOSER_FLAGS='--prefer-lowest'
-    - php: '7.0'
-      env:
-        - DOCTRINE_VERSION='~2.5.0'
-        - SYMFONY_VERSION='~3.1.0'
-
-    # Symfony bridge with Eloquent
-    - php: '7.0'
-      env:
-        - COVERAGE='true'
-        - ELOQUENT_VERSION='~5.3.0'
-        - SYMFONY_VERSION='~3.0.0'
-        - COMPOSER_FLAGS='--prefer-lowest'
-    - php: '7.0'
-      env:
-        - ELOQUENT_VERSION='~5.3.0'
-        - SYMFONY_VERSION='~3.1.0'
-
   allow_failures:
     - php: nightly
-    - php: '7.0'
-      env: ELOQUENT_VERSION='~5.3.0@dev'
-    - php: '7.0'
-      env: SYMFONY_VERSION='~3.2.0@dev'
+    - php: '7.1'
+    - Âenv: SYMFONY_VERSION='~3.2.0@dev'
 
 before_install:
   - set -eo pipefail
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  # From https://github.com/travis-ci/travis-ci/issues/5780#issuecomment-196308406
-  - |
-    XDEBUG_INI="/home/travis/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini"
-    if [ ! -f "$XDEBUG_INI" ]; then
-        return
+  - phpenv config-rm xdebug.ini || true
+  - if [ "$TRAVIS_PHP_VERSION" = "nightly" ]; then
+        COMPOSER_FLAGS="$COMPOSER_FLAGS --ignore-platform-reqs";
     fi
-    function composer()
-    {
-      mv $XDEBUG_INI ~/xdebug.ini
-      COMPOSER="$(which composer)"
-      $COMPOSER "$@"
-      STATUS=$?
-      mv ~/xdebug.ini $XDEBUG_INI
-
-      return $STATUS
-    }
-  - |
-    if [ "$TRAVIS_PHP_VERSION" = "nightly" ]; then
-        COMPOSER_FLAGS="$COMPOSER_FLAGS --ignore-platform-reqs"
-    fi
-  - PHPUNIT_BIN='vendor/bin/phpunit'
-  - PHPUNIT_CONFIG='phpunit.xml.dist'
   - PHPUNIT_FLAGS='--stop-on-failure --verbose'
 
 install:
   - composer update --prefer-dist $COMPOSER_FLAGS
-
-  - |
-    # Doctrine bridge
-    if [ -n "$DOCTRINE_VERSION" ] && [ -z "$SYMFONY_VERSION"]; then
-        composer bin doctrine require --dev --no-update "doctrine/orm:${DOCTRINE_VERSION}"
-
-        PHPUNIT_CONFIG='phpunit_doctrine.xml.dist'
-        PHPUNIT_BIN='vendor-bin/doctrine/vendor/phpunit/phpunit/phpunit'
-
-    # Eloquent bridge
-    elif [ -n "$ELOQUENT_VERSION" ] && [ -z "$SYMFONY_VERSION"]; then
-        composer bin eloquent require --dev --no-update "illuminate/database:${ELOQUENT_VERSION}"
-
-        PHPUNIT_CONFIG='phpunit_eloquent.xml.dist'
-        PHPUNIT_BIN='vendor-bin/eloquent/vendor/phpunit/phpunit/phpunit'
-
-    # Symfony bridge
-    elif [ -n "$SYMFONY_VERSION" ]; then
-        composer bin symfony require --dev --no-update symfony/symfony "symfony/symfony:${SYMFONY_VERSION}"
-
-        PHPUNIT_CONFIG='phpunit_symfony.xml.dist'
-        PHPUNIT_BIN='vendor-bin/symfony/vendor/phpunit/phpunit/phpunit'
-
-        # Symfony bridge with Doctrine
-        if [ -n "$DOCTRINE_VERSION" ]; then
-            composer bin symfony require --dev --no-update "doctrine/orm:${DOCTRINE_VERSION}"
-        fi
-        if [ -n "$ELOQUENT_VERSION" ]; then
-            composer bin symfony require --dev --no-update "illuminate/database:${ELOQUENT_VERSION}"
-        fi
+  - if [ -n "$SYMFONY_VERSION" ]; then
+        composer bin symfony require --dev --no-update "symfony/symfony:${SYMFONY_VERSION}";
+        composer bin proxy-manager require --dev --no-update "symfony/symfony:${SYMFONY_VERSION}";
     fi
-
+  - if [ -n "$ELOQUENT_VERSION" ]; then
+        composer bin eloquent require --dev --no-update "illuminate/database:${ELOQUENT_VERSION}";
+        composer bin symfony require --dev --no-update "illuminate/database:${ELOQUENT_VERSION}";
+        composer bin proxy-manager require --dev --no-update "illuminate/database:${ELOQUENT_VERSION}";
+    fi
+  - if [ -n "$DOCTRINE_VERSION" ]; then
+        composer bin doctrine require --dev --no-update "doctrine/orm:${DOCTRINE_VERSION}";
+        composer bin symfony require --dev --no-update "doctrine/orm:${DOCTRINE_VERSION}";
+        composer bin proxy-manager require --dev --no-update "doctrine/orm:${DOCTRINE_VERSION}";
+    fi
   - composer bin all update --prefer-dist $COMPOSER_FLAGS
-  - mysql -u root -e "create database IF NOT EXISTS fidry_alice_data_fixtures;"
 
-  - |
-    # Doctrine bridge
-    if [ -n "$DOCTRINE_VERSION" ] && [ -z "$SYMFONY_VERSION"]; then
-        php vendor-bin/doctrine/vendor/doctrine/orm/bin/doctrine o:s:c
-
-    # Eloquent bridge
-    elif [ -n "$ELOQUENT_VERSION" ] && [ -z "$SYMFONY_VERSION"]; then
-        php bin/eloquent_migrate
-
-    # Symfony with Doctrine
-    elif [ -n "$SYMFONY_VERSION" ] && [ -n "$DOCTRINE_VERSION"]; then
-        php bin/console d:s:c -k=DoctrineKernel
-
-    # Symfony with Eloquent
-    elif [ -n "$SYMFONY_VERSION" ] && [ -n "$ELOQUENT_VERSION" ]; then
-        php bin/console eloquent:migrate:install -k=EloquentKernel
-    fi
-
-script:
-  - |
-    if [ -n "$COVERAGE" ]; then
-        phpdbg -qrr $PHPUNIT_BIN -c $PHPUNIT_CONFIG $PHPUNIT_FLAGS --testdox --coverage-text
-    else
-        $PHPUNIT_BIN -c $PHPUNIT_CONFIG $PHPUNIT_FLAGS
-    fi
+script: bin/test.sh
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "theofidry/alice-data-fixtures",
-    "description": "Nelmio alice extension to persist the loaded fixtures",
+    "description": "Nelmio alice extension to persist the loaded fixtures.",
     "keywords": ["Fixture", "ORM", "Alice", "Faker", "data", "tests"],
     "type": "library",
     "license": "MIT",
@@ -13,18 +13,15 @@
     ],
     "require": {
         "php": "~7.0.0 || ~7.1.0",
-        "nelmio/alice": "^3.0@dev",
-        "phpspec/prophecy": "^1.6",
-        "phpunit/phpunit": "^5.5"
+        "nelmio/alice": "^3.0@dev"
     },
     "require-dev": {
-        "bamarni/composer-bin-plugin": "^1.0"
+        "bamarni/composer-bin-plugin": "^1.0",
+        "phpunit/phpunit": "^5.5",
+        "symfony/phpunit-bridge": "^3.1"
     },
     "suggest": {
         "doctrine/orm": "To use Doctrine ORM"
-    },
-    "scripts": {
-        "post-install-cmd": ["@composer bin all install --ansi"]
     },
     "autoload": {
         "psr-4": { "Fidry\\AliceDataFixtures\\": "src" }

--- a/fixtures/Bridge/Symfony/SymfonyApp/DoctrineKernel.php
+++ b/fixtures/Bridge/Symfony/SymfonyApp/DoctrineKernel.php
@@ -31,8 +31,11 @@ class DoctrineKernel extends Kernel
             new NelmioAliceBundle(),
             new FidryAliceDataFixturesBundle(),
             new DoctrineBundle(),
-            new PsyshBundle(),
         ];
+
+        if (class_exists('Fidry\PsyshBundle\PsyshBundle')) {
+            $bundles[] = new PsyshBundle();
+        }
 
         return $bundles;
     }

--- a/fixtures/Bridge/Symfony/SymfonyApp/EloquentKernel.php
+++ b/fixtures/Bridge/Symfony/SymfonyApp/EloquentKernel.php
@@ -31,8 +31,11 @@ class EloquentKernel extends Kernel
             new NelmioAliceBundle(),
             new FidryAliceDataFixturesBundle(),
             new WouterJEloquentBundle(),
-            new PsyshBundle(),
         ];
+
+        if (class_exists('Fidry\PsyshBundle\PsyshBundle')) {
+            $bundles[] = new PsyshBundle();
+        }
 
         return $bundles;
     }

--- a/phpunit_symfony_proxy_manager_with_doctrine.xml.dist
+++ b/phpunit_symfony_proxy_manager_with_doctrine.xml.dist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.5/phpunit.xsd"
+         bootstrap="vendor-bin/proxy-manager/vendor/autoload.php"
+         colors="true"
+         forceCoversAnnotation="true"
+         beStrictAboutCoversAnnotation="true"
+         stopOnFailure="true"
+         verbose="true">
+
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>tests/Bridge/Symfony/Doctrine</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>src/Bridge/Symfony/Doctrine</directory>
+        </whitelist>
+    </filter>
+
+</phpunit>

--- a/phpunit_symfony_proxy_manager_with_eloquent.xml.dist
+++ b/phpunit_symfony_proxy_manager_with_eloquent.xml.dist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.5/phpunit.xsd"
+         bootstrap="vendor-bin/proxy-manager/vendor/autoload.php"
+         colors="true"
+         forceCoversAnnotation="true"
+         beStrictAboutCoversAnnotation="true"
+         stopOnFailure="true"
+         verbose="true">
+
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>tests/Bridge/Symfony/Eloquent</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>tests/Bridge/Symfony/Eloquent</directory>
+        </whitelist>
+    </filter>
+
+</phpunit>

--- a/src/Bridge/Doctrine/Persister/ObjectManagerPersister.php
+++ b/src/Bridge/Doctrine/Persister/ObjectManagerPersister.php
@@ -17,8 +17,10 @@ use Nelmio\Alice\NotClonableTrait;
 
 /**
  * @author Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * @final
  */
-final class ObjectManagerPersister implements PersisterInterface
+/*final*/ class ObjectManagerPersister implements PersisterInterface
 {
     use NotClonableTrait;
 

--- a/src/Bridge/Doctrine/Purger/OrmPurger.php
+++ b/src/Bridge/Doctrine/Purger/OrmPurger.php
@@ -23,8 +23,10 @@ use Nelmio\Alice\NotClonableTrait;
  * Bridge for Doctrine ORM purger.
  *
  * @author Vincent CHALAMON <vincentchalamon@gmail.com>
+ *
+ * @final
  */
-final class OrmPurger implements PurgerInterface, PurgerFactoryInterface
+/*final*/ class OrmPurger implements PurgerInterface, PurgerFactoryInterface
 {
     use NotClonableTrait;
 

--- a/src/Loader/FileResolverLoader.php
+++ b/src/Loader/FileResolverLoader.php
@@ -19,8 +19,10 @@ use Nelmio\Alice\NotClonableTrait;
  * Decorates another loader to resolve files before loading them.
  *
  * @author Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * @final
  */
-final class FileResolverLoader implements LoaderInterface
+/*final*/ class FileResolverLoader implements LoaderInterface
 {
     use NotClonableTrait;
 

--- a/src/Loader/MultiPassLoader.php
+++ b/src/Loader/MultiPassLoader.php
@@ -24,8 +24,10 @@ use Nelmio\Alice\ParameterBag;
  * Alternative to {@se SimpleLoader} to load the files in a smarter way.
  *
  * @author Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * @final
  */
-final class MultiPassLoader implements LoaderInterface
+/*final*/ class MultiPassLoader implements LoaderInterface
 {
     use NotClonableTrait;
 

--- a/src/Loader/PersisterLoader.php
+++ b/src/Loader/PersisterLoader.php
@@ -22,8 +22,10 @@ use Nelmio\Alice\NotClonableTrait;
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  * @author Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * @final
  */
-final class PersisterLoader implements LoaderInterface, PersisterAwareInterface
+/*final*/ class PersisterLoader implements LoaderInterface, PersisterAwareInterface
 {
     use NotClonableTrait;
 

--- a/src/Loader/PurgerLoader.php
+++ b/src/Loader/PurgerLoader.php
@@ -20,8 +20,10 @@ use Nelmio\Alice\NotClonableTrait;
  * Loader decorating another loader to purge the database before loading.
  *
  * @author Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * @final
  */
-final class PurgerLoader implements LoaderInterface
+/*final*/ class PurgerLoader implements LoaderInterface
 {
     use NotClonableTrait;
 

--- a/src/Loader/SimpleLoader.php
+++ b/src/Loader/SimpleLoader.php
@@ -23,8 +23,10 @@ use Nelmio\Alice\ParameterBag;
  *
  * @author Baldur Rensch <brensch@gmail.com>
  * @author Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * @final
  */
-final class SimpleLoader implements LoaderInterface
+/*final*/ class SimpleLoader implements LoaderInterface
 {
     use NotClonableTrait;
 

--- a/tests/Bridge/Symfony/ProxyManager/Doctrine/FidryAliceDataFixturesBundleTest.php
+++ b/tests/Bridge/Symfony/ProxyManager/Doctrine/FidryAliceDataFixturesBundleTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Fidry\AliceDataFixtures package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fidry\AliceDataFixtures\Bridge\Symfony\ProxyManager\Doctrine;
+
+use Fidry\AliceDataFixtures\Bridge\Doctrine\Persister\ObjectManagerPersister;
+use Fidry\AliceDataFixtures\Bridge\Doctrine\Purger\OrmPurger;
+use Fidry\AliceDataFixtures\Bridge\Symfony\FidryAliceDataFixturesBundleTest as NakedFidryAliceDataFixturesBundleTest;
+use Fidry\AliceDataFixtures\Bridge\Symfony\SymfonyApp\DoctrineKernel;
+use Fidry\AliceDataFixtures\Loader\PersisterLoader;
+use Fidry\AliceDataFixtures\Loader\PurgerLoader;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * @coversNothing
+ *
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+class FidryAliceDataFixturesBundleTest extends NakedFidryAliceDataFixturesBundleTest
+{
+    /**
+     * @var KernelInterface
+     */
+    protected $kernel;
+
+    public function setUp()
+    {
+        $this->kernel = new DoctrineKernel('doctrine', true);
+        $this->kernel->boot();
+    }
+
+    public function tearDown()
+    {
+        $this->kernel->shutdown();
+    }
+
+    public function testServiceRegistration()
+    {
+        parent::testServiceRegistration();
+
+        $this->assertInstanceOf(
+            OrmPurger::class,
+            $this->kernel->getContainer()->get('fidry_alice_data_fixtures.persistence.purger.doctrine.orm_purger')
+        );
+
+        $this->assertInstanceOf(
+            ObjectManagerPersister::class,
+            $this->kernel->getContainer()->get('fidry_alice_data_fixtures.persistence.persister.doctrine.object_manager_persister')
+        );
+
+        $this->assertInstanceOf(
+            PersisterLoader::class,
+            $this->kernel->getContainer()->get('fidry_alice_data_fixtures.doctrine.persister_loader')
+        );
+
+        $this->assertInstanceOf(
+            PurgerLoader::class,
+            $this->kernel->getContainer()->get('fidry_alice_data_fixtures.doctrine.purger_loader')
+        );
+    }
+}

--- a/tests/Bridge/Symfony/ProxyManager/Eloquent/FidryAliceDataFixturesBundleTest.php
+++ b/tests/Bridge/Symfony/ProxyManager/Eloquent/FidryAliceDataFixturesBundleTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Fidry\AliceDataFixtures package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fidry\AliceDataFixtures\Bridge\Symfony\ProxyManager\Eloquent;
+
+use Fidry\AliceDataFixtures\Bridge\Eloquent\Persister\ModelPersister;
+use Fidry\AliceDataFixtures\Bridge\Eloquent\Purger\ModelPurger;
+use Fidry\AliceDataFixtures\Bridge\Symfony\FidryAliceDataFixturesBundleTest as NakedFidryAliceDataFixturesBundleTest;
+use Fidry\AliceDataFixtures\Bridge\Symfony\SymfonyApp\EloquentKernel;
+use Fidry\AliceDataFixtures\Loader\PersisterLoader;
+use Fidry\AliceDataFixtures\Loader\PurgerLoader;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * @coversNothing
+ *
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+class FidryAliceDataFixturesBundleTest extends NakedFidryAliceDataFixturesBundleTest
+{
+    /**
+     * @var KernelInterface
+     */
+    protected $kernel;
+
+    public function setUp()
+    {
+        $this->kernel = new EloquentKernel('eloquent', true);
+        $this->kernel->boot();
+    }
+
+    public function tearDown()
+    {
+        $this->kernel->shutdown();
+    }
+
+    public function testServiceRegistration()
+    {
+        parent::testServiceRegistration();
+
+        $this->assertInstanceOf(
+            ModelPurger::class,
+            $this->kernel->getContainer()->get('fidry_alice_data_fixtures.persistence.purger.eloquent.model_purger')
+        );
+
+        $this->assertInstanceOf(
+            ModelPersister::class,
+            $this->kernel->getContainer()->get('fidry_alice_data_fixtures.persistence.persister.eloquent.model_persister')
+        );
+
+        $this->assertInstanceOf(
+            PersisterLoader::class,
+            $this->kernel->getContainer()->get('fidry_alice_data_fixtures.eloquent.persister_loader')
+        );
+
+        $this->assertInstanceOf(
+            PurgerLoader::class,
+            $this->kernel->getContainer()->get('fidry_alice_data_fixtures.eloquent.purger_loader')
+        );
+    }
+}

--- a/vendor-bin/proxy-manager/composer.json
+++ b/vendor-bin/proxy-manager/composer.json
@@ -1,0 +1,21 @@
+{
+    "autoload-dev": {
+        "classmap": [
+            "../../migrations"
+        ]
+    },
+    "require-dev": {
+        "doctrine/data-fixtures": "^1.2",
+        "doctrine/doctrine-bundle": "^1.6",
+        "doctrine/orm": "^2.5",
+        "ocramius/proxy-manager": "^2.0",
+        "symfony/symfony": "^3.1",
+        "theofidry/composer-inheritance-plugin": "^1.0@dev",
+        "theofidry/psysh-bundle": "^2.0@dev",
+        "wouterj/eloquent-bundle": "^1.0@dev"
+    },
+    "config": {
+        "bin-dir": "bin",
+        "sort-packages": true
+    }
+}


### PR DESCRIPTION
- Simplify the Travis build (closes #20)
- Add tests for Ocramius ProxyManager support (closes #16)
- Upgraded to Eloquent `~5.3.0` (required by [WouterJEloquentBundle](https://github.com/wouterj/WouterJEloquentBundle))
- The Eloquent bridge requires https://github.com/wouterj/WouterJEloquentBundle/pull/37 to work