### PR TITLE
Allow using different names than "default" for entity manager.

### DIFF
--- a/src/Bridge/Symfony/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Resources/config/doctrine_orm.xml
@@ -22,14 +22,14 @@
         <service id="fidry_alice_data_fixtures.persistence.purger.doctrine.orm_purger"
                  class="Fidry\AliceDataFixtures\Bridge\Doctrine\Purger\OrmPurger"
                  lazy="true">
-            <argument type="service" id="doctrine.orm.default_entity_manager" />
+            <argument type="service" id="doctrine.orm.entity_manager" />
             <argument type="service" id="fidry_alice_data_fixtures.persistence.purger_mode" />
         </service>
 
         <service id="fidry_alice_data_fixtures.persistence.persister.doctrine.object_manager_persister"
                  class="Fidry\AliceDataFixtures\Bridge\Doctrine\Persister\ObjectManagerPersister"
                  lazy="true">
-            <argument type="service" id="doctrine.orm.default_entity_manager" />
+            <argument type="service" id="doctrine.orm.entity_manager" />
         </service>
 
         <service id="fidry_alice_data_fixtures.doctrine.persister_loader"


### PR DESCRIPTION
I would like to have an ability to use different names than "default" for my entity managers when using AliceDataFixtures. Doctrine has default_entity_manager option and it will point specified entity manager name to orm_entity_manager in a container or will use first on the list of configured entity managers.