### PR TITLE
Made persister/purger loaders services public

### DIFF
--- a/src/Bridge/Symfony/Resources/config/doctrine_mongodb_odm.xml
+++ b/src/Bridge/Symfony/Resources/config/doctrine_mongodb_odm.xml
@@ -27,14 +27,16 @@
 
         <service id="fidry_alice_data_fixtures.doctrine_mongodb.purger_loader"
                  class="Fidry\AliceDataFixtures\Loader\PurgerLoader"
-                 lazy="true" >
+                 lazy="true"
+                 public="true">
             <argument type="service" id="fidry_alice_data_fixtures.doctrine_mongodb.persister_loader" />
             <argument type="service" id="fidry_alice_data_fixtures.persistence.purger_factory.doctrine_mongodb" />
         </service>
 
         <service id="fidry_alice_data_fixtures.doctrine_mongodb.persister_loader"
                  class="Fidry\AliceDataFixtures\Loader\PersisterLoader"
-                 lazy="true" >
+                 lazy="true"
+                 public="true">
             <argument type="service" id="fidry_alice_data_fixtures.loader.simple" />
             <argument type="service" id="fidry_alice_data_fixtures.persistence.persister.doctrine_mongodb" />
             <!-- Processors are injected via a Compiler pass -->

--- a/src/Bridge/Symfony/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Resources/config/doctrine_orm.xml
@@ -26,14 +26,16 @@
 
         <service id="fidry_alice_data_fixtures.doctrine.purger_loader"
                  class="Fidry\AliceDataFixtures\Loader\PurgerLoader"
-                 lazy="true" >
+                 lazy="true"
+                 public="true">
             <argument type="service" id="fidry_alice_data_fixtures.doctrine.persister_loader" />
             <argument type="service" id="fidry_alice_data_fixtures.persistence.purger_factory.doctrine" />
         </service>
 
         <service id="fidry_alice_data_fixtures.doctrine.persister_loader"
                  class="Fidry\AliceDataFixtures\Loader\PersisterLoader"
-                 lazy="true" >
+                 lazy="true"
+                 public="true">
             <argument type="service" id="fidry_alice_data_fixtures.loader.simple" />
             <argument type="service" id="fidry_alice_data_fixtures.persistence.persister.doctrine" />
             <!-- Processors are injected via a Compiler pass -->

--- a/src/Bridge/Symfony/Resources/config/doctrine_phpcr_odm.xml
+++ b/src/Bridge/Symfony/Resources/config/doctrine_phpcr_odm.xml
@@ -26,14 +26,16 @@
 
         <service id="fidry_alice_data_fixtures.doctrine_phpcr.purger_loader"
                  class="Fidry\AliceDataFixtures\Loader\PurgerLoader"
-                 lazy="true" >
+                 lazy="true"
+                 public="true">
             <argument type="service" id="fidry_alice_data_fixtures.doctrine_phpcr.persister_loader" />
             <argument type="service" id="fidry_alice_data_fixtures.persistence.purger_factory.doctrine_phpcr" />
         </service>
 
         <service id="fidry_alice_data_fixtures.doctrine_phpcr.persister_loader"
                  class="Fidry\AliceDataFixtures\Loader\PersisterLoader"
-                 lazy="true" >
+                 lazy="true"
+                 public="true">
             <argument type="service" id="fidry_alice_data_fixtures.loader.simple" />
             <argument type="service" id="fidry_alice_data_fixtures.persistence.persister.doctrine_phpcr" />
             <!-- Processors are injected via a Compiler pass -->

--- a/src/Bridge/Symfony/Resources/config/eloquent_orm.xml
+++ b/src/Bridge/Symfony/Resources/config/eloquent_orm.xml
@@ -30,14 +30,16 @@
 
         <service id="fidry_alice_data_fixtures.eloquent.purger_loader"
                  class="Fidry\AliceDataFixtures\Loader\PurgerLoader"
-                 lazy="true" >
+                 lazy="true"
+                 public="true">
             <argument type="service" id="fidry_alice_data_fixtures.eloquent.persister_loader" />
             <argument type="service" id="fidry_alice_data_fixtures.persistence.purger_factory.eloquent" />
         </service>
 
         <service id="fidry_alice_data_fixtures.eloquent.persister_loader"
                  class="Fidry\AliceDataFixtures\Loader\PersisterLoader"
-                 lazy="true" >
+                 lazy="true"
+                 public="true">
             <argument type="service" id="fidry_alice_data_fixtures.loader.simple" />
             <argument type="service" id="fidry_alice_data_fixtures.persistence.persister.eloquent" />
             <!-- Processors are injected via a Compiler pass -->


### PR DESCRIPTION
This allows to easily choose between a purger or simple persister loader from tests or doctrine fixtures by accessing them directly from the container.

But in fact, what is bothering me is that the already public `fidry_alice_data_fixtures.loader.doctrine` alias (and similar ones for other ORM/ODMs) is aliasing the purger loader, and there is no way to not purge, [even by passing `null` as `$purgeMode`](https://github.com/theofidry/AliceDataFixtures/blob/master/src/Loader/PurgerLoader.php#L67-L69). 😕 