### PR TITLE
Add a NO_PURGE mode

### DIFF
--- a/src/Loader/PurgerLoader.php
+++ b/src/Loader/PurgerLoader.php
@@ -68,8 +68,10 @@ use Nelmio\Alice\IsAServiceTrait;
             $purgeMode = PurgeMode::createDeleteMode();
         }
 
-        $purger = $this->purgerFactory->create($purgeMode);
-        $purger->purge();
+        if ($purgeMode != PurgeMode::createNoPurgeMode()) {
+            $purger = $this->purgerFactory->create($purgeMode);
+            $purger->purge();
+        }
 
         return $this->loader->load($fixturesFiles, $parameters, $objects, $purgeMode);
     }

--- a/src/Persistence/PurgeMode.php
+++ b/src/Persistence/PurgeMode.php
@@ -18,6 +18,7 @@ use InvalidArgumentException;
 final class PurgeMode
 {
     private static $values = [
+        'NO_PURGE_MODE' => 0,
         'DELETE_MODE' => 1,
         'TRUNCATE_MODE' => 2,
     ];
@@ -45,6 +46,11 @@ final class PurgeMode
     public static function createTruncateMode(): self
     {
         return new self(self::$values['TRUNCATE_MODE']);
+    }
+
+    public static function createNoPurgeMode(): self
+    {
+        return new self(self::$values['NO_PURGE_MODE']);
     }
 
     public function getValue(): int

--- a/tests/Persistence/PurgeModeTest.php
+++ b/tests/Persistence/PurgeModeTest.php
@@ -22,11 +22,11 @@ class PurgeModeTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unknown purge mode "0".
+     * @expectedExceptionMessage Unknown purge mode "3".
      */
     public function testThrowsAnExceptionIfUnknownPurgeModeIsGiven()
     {
-        new PurgeMode(0);
+        new PurgeMode(3);
     }
 
     public function testCanCreateDeleteMode()


### PR DESCRIPTION
Trying to keep things simple: the `NO_PURGE` mode is handled in `PurgerLoader`, not in each `PurgerInterface` implementation.