### PR TITLE
If $logger is optional, $processors should be too

### DIFF
--- a/src/Loader/PersisterLoader.php
+++ b/src/Loader/PersisterLoader.php
@@ -42,13 +42,14 @@ use Psr\Log\NullLogger;
     /**
      * @param LoaderInterface      $decoratedLoader
      * @param PersisterInterface   $persister
+     * @param LoggerInterface|null $logger
      * @param ProcessorInterface[] $processors
      */
     public function __construct(
         LoaderInterface $decoratedLoader,
         PersisterInterface $persister,
         LoggerInterface $logger = null,
-        array $processors
+        array $processors = []
     ) {
         $this->loader = $decoratedLoader;
         $this->persister = $persister;


### PR DESCRIPTION
If `$logger` is optional, `$processors` should be too. I also added the missing doc for `$logger`.