### PR TITLE
Fix documentation of ProcessorInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ final class UserProcessor implements ProcessorInterface
     /**
      * @inheritdoc
      */
-    public function preProcess($object)
+    public function preProcess(string $fixtureId, $object): void
     {
         if (false === $object instanceof User) {
             return;
@@ -307,7 +307,7 @@ final class UserProcessor implements ProcessorInterface
     /**
      * @inheritdoc
      */
-    public function postProcess($object)
+    public function postProcess(string $fixtureId, $object): void
     {
         // do nothing
     }


### PR DESCRIPTION
This PR fixes the documentation of `ProcessorInterface::{pre,post}Process` which got a second parameter some time ago.