### PR TITLE
Add a gitattribute file to exclude test fixtures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/tests export-ignore
+/fixtures export-ignore
+/vendor-bin export-ignore
+/bin export-ignore
+/phpunit*.xml.dist export-ignore
+/Makefile export-ignore


### PR DESCRIPTION
Including test fixtures in the downloadable archive creates confusion for static analysis tools (IDEs, Scrutinizer, etc...) due to the fake classes in them. For instance, when analyzing my project after the upgrade to Alice 3, Scrutinizer decided that `$this->registry->getManager()` in my code was returning a `\Fidry\AliceDataFixtures\Bridge\Doctrine\ORM\FakeEntityManager` rather than a `Doctrine\ORM\EntityManager`.

These files are not needed in the archive.