### PR TITLE
Exclude more root files from the archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,12 @@
 /tests export-ignore
 /fixtures export-ignore
+/migrations export-ignore
 /vendor-bin export-ignore
 /bin export-ignore
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/cli-config.php export-ignore
 /phpunit*.xml.dist export-ignore
 /Makefile export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,7 @@
 /vendor-bin/*/vendor/
 /dist/
 /bin/
-!/bin/clear_cache.sh
 !/bin/console
 !/bin/doctrine_purge
 !/bin/eloquent_migrate
 !/bin/eloquent_rollback
-!/bin/propel_init


### PR DESCRIPTION
Follow-up of #98 to remove more things.

Only things kept are:

- the `src` folder (of course necessary)
- the `LICENSE` file (mandatory)
- the `README.md` file (that could be discussed)
- the `composer.json` file (composer does not actually care about that one, but some third-party tools are relying on it to identify third-party packages instead of relying on the composer metadata about installed packages)

I also cleaned the gitignore file from outdated unignored files.