### PR TITLE
Issue with automatically disabling doctrine id generator

### DIFF
--- a/fixtures/Bridge/Doctrine/Entity/DummyWithRelatedCascadePersist.php
+++ b/fixtures/Bridge/Doctrine/Entity/DummyWithRelatedCascadePersist.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Fidry\AliceDataFixtures package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\AliceDataFixtures\Bridge\Doctrine\Entity;
+
+/**
+ * @Entity
+ */
+class DummyWithRelatedCascadePersist
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    public $id;
+
+    /**
+     * @ManyToOne(targetEntity="Dummy", cascade={"persist"})
+     */
+    public $related;
+}


### PR DESCRIPTION
So here's a failing test case for the problem described in https://github.com/theofidry/AliceDataFixtures/pull/68.

I'll try it again in other words though:

Disabling the id generator automatically when loading fixtures is really super handy. It's always needed and really comfortable. I can just simply specify something like this and my `id` is not autogenerated even though I have an autogenerator registered for production:

```yaml
App\Entity\Group:
    group_1:
        id: 44b178b5-ea58-44bf-857f-eb8ce4df1280
```

Now here's where it gets a bit tricky: If you have related entities with `cascade: persist` (which is very common I guess), disabling the id generator happens too late for some of the entities.
Imagine this:

```yaml
App\Entity\Group:
    group_1:
        id: 44b178b5-ea58-44bf-857f-eb8ce4df1280

App\Entity\User:
    user_1:
        id: b3c52f50-992f-44fd-bc71-95acc1eef687
        group: "@group_1"
```

The way the fixture loader works is it persists every object one after the other. So it will persist `group_1` first and only then `user_1`. Now if you do not have `cascade: persist` configured, it works just fine. However, if you configured `cascade: persist` the `id` for `user_1` is generated during `->persist($group1)` already.

So handling this in the `ObjectManagerPersister` does not work. Disabling the UUID generation has to be done **before any** of the objects is being persisted.
So either we need a special loader (which I don't really like because loading is actually not affected) or we have to have a new interface a `Processor` can implement that is called **before** the persister is asked to persist **any** object.