### PR TITLE
Outlined how disabling the id generator could be fixed

### DIFF
--- a/src/Bridge/Symfony/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Resources/config/doctrine_orm.xml
@@ -42,6 +42,13 @@
             <!-- Processors are injected via a Compiler pass -->
         </service>
 
+        <!-- Processors -->
+        <service id="fidry_alice_data_fixtures.doctrine.auto_disable_doctrine_id_generator_processor"
+                 class="Fidry\AliceDataFixtures\Processor\AutoDisableDoctrineIdGeneratorProcessor"
+                 lazy="true" >
+            <argument type="service" id="doctrine.orm.entity_manager" />
+            <tag name="fidry_alice_data_fixtures.processor" />
+        </service>
 
         <!-- Purger Factory -->
 

--- a/src/ExtendedProcessorInterface.php
+++ b/src/ExtendedProcessorInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Fidry\AliceDataFixtures package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\AliceDataFixtures;
+
+/**
+ * Processor are meant to be used during the loading of files via a {@see LoaderInterface} in the scenario of having the
+ * loaded objects persisted in the database.
+ * The ExtendedProcessorInterface is called before **any** of the objects and after **all** of them
+ * are being persisted.
+ *
+ * @see \Fidry\AliceDataFixtures\Loader\PersisterLoader For an example of usage of processors
+ */
+interface ExtendedProcessorInterface
+{
+    /**
+     * Allows to pre process all objects before any of them is persisted.
+     *
+     * @param object[] $objects An array where the key represents the fixture id and the value the object
+     */
+    public function preProcessAllObjects(array $objects): void;
+
+    /**
+     * Allows to pre process all objects before any of them is persisted.
+     *
+     * @param object[] $objects An array where the key represents the fixture id and the value the object
+     */
+    public function postProcessAllObjects(array $objects): void;
+}

--- a/src/Processor/AutoDisableDoctrineIdGeneratorProcessor.php
+++ b/src/Processor/AutoDisableDoctrineIdGeneratorProcessor.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Fidry\AliceDataFixtures package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\AliceDataFixtures\Processor;
+
+
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\ObjectManager;
+use Fidry\AliceDataFixtures\ExtendedProcessorInterface;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo as ODMClassMetadataInfo;
+use Doctrine\ORM\Id\AssignedGenerator as ORMAssignedGenerator;
+use Doctrine\ORM\Mapping\ClassMetadataInfo as ORMClassMetadataInfo;
+
+class AutoDisableDoctrineIdGeneratorProcessor implements ExtendedProcessorInterface
+{
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @var ClassMetadata[] Entity metadata, FQCN being the key
+     */
+    private $metadata = [];
+
+    /**
+     * @var array
+     */
+    private $idGeneratorData = [];
+
+    public function __construct(ObjectManager $manager)
+    {
+        $this->objectManager = $manager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preProcessAllObjects(array $objects): void
+    {
+        foreach ($objects as $object) {
+            $class = get_class($object);
+            $metadata = $this->getMetadata($class);
+
+            // Check if the ID is explicitly set by the user. To avoid the ID to be overridden by the ID generator
+            // registered, we disable it for that specific object.
+            if ($metadata instanceof ORMClassMetadataInfo) {
+                if ($metadata->usesIdGenerator() && false === empty($metadata->getIdentifierValues($object))) {
+                    $this->idGeneratorData[$class] = [
+                        'generator' => $metadata->idGenerator,
+                        'generatorType' => $metadata->generatorType,
+                    ];
+
+                    $this->configureIdGenerator($metadata);
+                }
+            } elseif ($metadata instanceof ODMClassMetadataInfo) {
+                // Do nothing: currently not supported as Doctrine ODM does not have an equivalent of the ORM
+                // AssignedGenerator.
+            } else {
+                // Do nothing: not supported.
+            }
+        }
+    }
+
+    private function getMetadata(string $class): ClassMetadata
+    {
+        if (false === array_key_exists($class, $this->metadata)) {
+            $classMetadata = $this->objectManager->getClassMetadata($class);
+            $this->metadata[$class] = $classMetadata;
+        }
+        return $this->metadata[$class];
+    }
+
+    protected function configureIdGenerator(ORMClassMetadataInfo $metadata): void
+    {
+        $metadata->setIdGeneratorType(ORMClassMetadataInfo::GENERATOR_TYPE_NONE);
+        $metadata->setIdGenerator(new ORMAssignedGenerator());
+    }
+
+    /**
+     * Allows to pre process all objects before any of them is persisted.
+     *
+     * @param object[] $objects An array where the key represents the fixture id and the value the object
+     */
+    public function postProcessAllObjects(array $objects): void
+    {
+        foreach ($objects as $object) {
+            $class = get_class($object);
+
+            if (!isset($this->idGeneratorData[$class])) {
+                return;
+            }
+
+            $metadata = $this->getMetadata($class);
+
+            $generator = $this->idGeneratorData[$class]['generator'];
+            $generatorType = $this->idGeneratorData[$class]['generatorType'];
+
+            if (null !== $generator && false === $generator->isPostInsertGenerator()) {
+                // Restore the generator if has been temporary unset
+                $metadata->setIdGeneratorType($generatorType);
+                $metadata->setIdGenerator($generator);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Here's just quickly outlined how https://github.com/theofidry/AliceDataFixtures/pull/110 could be fixed.
The core issue here is just that we need to be able to disable id generation for **all** objects before any of them is persisted so I had to add a new interface which I - creative as I am - named `ExtendedProcessorInterface`. All I did then was moving the logic away from the `ObjectManagerPersister` into a processor that uses this new interface.

This is how the issue could be fixed. /cc @dkarlovi 