### PR TITLE
Fixed root_node deprecation with Symfony 4.2

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -31,8 +31,13 @@ final class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('fidry_alice_data_fixtures');
+        $treeBuilder = new TreeBuilder('fidry_alice_data_fixtures');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('fidry_alice_data_fixtures');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
Hi, this PR fixes a small deprecation introduced in Symfony 4.2; the fix includes a BC layer for older versions.