### PR TITLE
Disable FK checks also on DELETE

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,7 +20,7 @@
          verbose="true">
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
     </php>
 
     <testsuites>

--- a/phpunit_doctrine.xml.dist
+++ b/phpunit_doctrine.xml.dist
@@ -20,7 +20,7 @@
          verbose="true">
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
 
         <env name="DB_DRIVER" value="pdo_mysql" />
         <env name="DB_USER" value="root" />

--- a/phpunit_doctrine_mongodb.xml.dist
+++ b/phpunit_doctrine_mongodb.xml.dist
@@ -20,7 +20,7 @@
          verbose="true">
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
     </php>
 
     <testsuites>

--- a/phpunit_doctrine_phpcr.xml.dist
+++ b/phpunit_doctrine_phpcr.xml.dist
@@ -21,7 +21,7 @@
          verbose="true">
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="4" />
 
         <env name="DB_DRIVER" value="pdo_mysql" />
         <env name="DB_USER" value="root" />

--- a/phpunit_doctrine_phpcr.xml.dist
+++ b/phpunit_doctrine_phpcr.xml.dist
@@ -21,7 +21,7 @@
          verbose="true">
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
 
         <env name="DB_DRIVER" value="pdo_mysql" />
         <env name="DB_USER" value="root" />

--- a/phpunit_eloquent.xml.dist
+++ b/phpunit_eloquent.xml.dist
@@ -20,7 +20,7 @@
          verbose="true">
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
 
         <env name="DB_DRIVER" value="mysql" />
         <env name="DB_USER" value="root" />

--- a/phpunit_propel2.xml.dist
+++ b/phpunit_propel2.xml.dist
@@ -20,7 +20,7 @@
          verbose="true">
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
     </php>
 
     <testsuites>

--- a/phpunit_symfony.xml.dist
+++ b/phpunit_symfony.xml.dist
@@ -20,7 +20,7 @@
          verbose="true">
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
     </php>
 
     <testsuites>

--- a/phpunit_symfony_doctrine.xml.dist
+++ b/phpunit_symfony_doctrine.xml.dist
@@ -20,7 +20,7 @@
          verbose="true">
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="5" />
     </php>
 
     <testsuites>

--- a/phpunit_symfony_doctrine.xml.dist
+++ b/phpunit_symfony_doctrine.xml.dist
@@ -20,7 +20,7 @@
          verbose="true">
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
     </php>
 
     <testsuites>

--- a/phpunit_symfony_eloquent.xml.dist
+++ b/phpunit_symfony_eloquent.xml.dist
@@ -20,7 +20,7 @@
          verbose="true">
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
     </php>
 
     <testsuites>

--- a/phpunit_symfony_proxy_manager_with_doctrine.xml.dist
+++ b/phpunit_symfony_proxy_manager_with_doctrine.xml.dist
@@ -20,7 +20,7 @@
          verbose="true">
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="5" />
     </php>
 
     <testsuites>

--- a/phpunit_symfony_proxy_manager_with_doctrine.xml.dist
+++ b/phpunit_symfony_proxy_manager_with_doctrine.xml.dist
@@ -20,7 +20,7 @@
          verbose="true">
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
     </php>
 
     <testsuites>

--- a/phpunit_symfony_proxy_manager_with_eloquent.xml.dist
+++ b/phpunit_symfony_proxy_manager_with_eloquent.xml.dist
@@ -20,7 +20,7 @@
          verbose="true">
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="0" />
     </php>
 
     <testsuites>

--- a/vendor-bin/proxy-manager/composer.json
+++ b/vendor-bin/proxy-manager/composer.json
@@ -14,7 +14,7 @@
         "doctrine/phpcr-bundle": "^1.0",
         "doctrine/phpcr-odm": "^1.4",
         "jackalope/jackalope-doctrine-dbal": "^1.2",
-        "ocramius/proxy-manager": "^2.0.2",
+        "ocramius/proxy-manager": "^2.0.2, < 2.2.0",
         "psy/psysh": "^0.6",
         "symfony/symfony": "^3.4 || ^4.0",
         "theofidry/composer-inheritance-plugin": "^1.0",


### PR DESCRIPTION
Actually I'm facing the same issue with the DELETE purge mode. I got the following error when trying to refresh my database.

> In AbstractMySQLDriver.php line 49:
>                                                                                                                               
>   An exception occurred while executing 'DELETE FROM portal':                                                                 
>                                                                                                                               
>   SQLSTATE[23000]: Integrity constraint violation: 1217 Cannot delete or update a parent row: a foreign key constraint fails 