### PR TITLE
Add symfony 4.4/5.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
         composer bin symfony require --dev --no-update "symfony/symfony:${SYMFONY_VERSION}";
         composer bin proxy-manager require --dev --no-update "symfony/symfony:${SYMFONY_VERSION}";
     fi
-  - if [ -n "$SYMFONY_VERSION" == '~4.0.0' ] || [ -n "$SYMFONY_VERSION" == '~4.1.0@dev' ]; then
+  - if [ -n "$SYMFONY_VERSION" == '~4.4.0' ] || [ -n "$SYMFONY_VERSION" == '5.0.0' ]; then
         composer bin symfony require --dev --no-update "doctrine/phpcr-bundle";
         composer bin symfony require --dev --no-update "doctrine/phpcr-odm:^2.0@dev";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,14 +28,12 @@ matrix:
     - php: '7.2'
       env: SYMFONY_VERSION='~3.4.0'
     - php: '7.2'
-      env: SYMFONY_VERSION='~4.0.0'
+      env: SYMFONY_VERSION='~4.4.0'
     - php: '7.2'
-      env: SYMFONY_VERSION='~4.1.0@dev'
+      env: SYMFONY_VERSION='~5.0.0'
 
   allow_failures:
     - php: nightly
-    - env: SYMFONY_VERSION='~4.0.0'
-    - env: SYMFONY_VERSION='~4.1.0@dev'
 
 before_install:
   - set -eo pipefail

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "bamarni/composer-bin-plugin": "^1.1",
         "phpspec/prophecy": "^1.7",
         "phpunit/phpunit": "^6.0",
-        "symfony/phpunit-bridge": "^3.3.2 || ^4.0"
+        "symfony/phpunit-bridge": "^3.3.2 || ^4.0 || ^5.0"
     },
     "conflict": {
         "doctrine/orm": "<2.5",

--- a/fixtures/Bridge/Doctrine/MongoDocument/DummyWithEmbeddable.php
+++ b/fixtures/Bridge/Doctrine/MongoDocument/DummyWithEmbeddable.php
@@ -28,7 +28,7 @@ class DummyWithEmbeddable
     public $id;
 
     /**
-     * @EmbedOne(targetDocument="DummyEmbeddable")
+     * @EmbedOne(targetDocument="Fidry\AliceDataFixtures\Bridge\Doctrine\MongoDocument\DummyEmbeddable")
      */
     public $embeddable;
 }

--- a/fixtures/Bridge/Symfony/SymfonyApp/config/doctrine/Dummy.mongodb.xml
+++ b/fixtures/Bridge/Symfony/SymfonyApp/config/doctrine/Dummy.mongodb.xml
@@ -12,7 +12,7 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <document name="Fidry\AliceDataFixtures\Bridge\Symfony\MongoDocument\Dummy">
-        <field name="id" type="id" id="true" />
+        <id/>
     </document>
 
 </doctrine-mongo-mapping>

--- a/fixtures/Bridge/Symfony/SymfonyApp/config/doctrine/DummyWithEmbeddable.mongodb.xml
+++ b/fixtures/Bridge/Symfony/SymfonyApp/config/doctrine/DummyWithEmbeddable.mongodb.xml
@@ -12,9 +12,9 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <document name="Fidry\AliceDataFixtures\Bridge\Symfony\MongoDocument\DummyWithEmbeddable">
-        <field name="id" type="id" id="true" />
+        <id/>
         <embed-one field="embeddable"
-                   target-document="DummyEmbeddable" />
+                   target-document="Fidry\AliceDataFixtures\Bridge\Symfony\MongoDocument\DummyEmbeddable" />
     </document>
 
 </doctrine-mongo-mapping>

--- a/fixtures/Bridge/Symfony/SymfonyApp/config/doctrine/DummyWithEmbeddable.orm.xml
+++ b/fixtures/Bridge/Symfony/SymfonyApp/config/doctrine/DummyWithEmbeddable.orm.xml
@@ -16,7 +16,7 @@
         <id name="id" type="integer">
             <generator strategy="AUTO" />
         </id>
-        <embedded name="embeddable" class="DummyEmbeddable" />
+        <embedded name="embeddable" class="Fidry\AliceDataFixtures\Bridge\Symfony\Entity\DummyEmbeddable" />
     </entity>
 
 </doctrine-mapping>

--- a/fixtures/Bridge/Symfony/SymfonyApp/config/doctrine/MappedSuperclassDummy.mongodb.xml
+++ b/fixtures/Bridge/Symfony/SymfonyApp/config/doctrine/MappedSuperclassDummy.mongodb.xml
@@ -12,7 +12,7 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <mapped-superclass name="Fidry\AliceDataFixtures\Bridge\Symfony\MongoDocument\MappedSuperclassDummy">
-        <field name="id" type="id" id="true" />
+        <id/>
         <field name="status" type="string" />
     </mapped-superclass>
 

--- a/phpunit_symfony_doctrine.xml.dist
+++ b/phpunit_symfony_doctrine.xml.dist
@@ -20,7 +20,7 @@
          verbose="true">
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="5" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="26" />
     </php>
 
     <testsuites>

--- a/phpunit_symfony_proxy_manager_with_doctrine.xml.dist
+++ b/phpunit_symfony_proxy_manager_with_doctrine.xml.dist
@@ -20,7 +20,7 @@
          verbose="true">
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="5" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="27" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
This adds support for Symfony 4.4 and Symfony 5.0. I think I also fixed some unrelated deprecations.

I had to increase the number of allowed deprecations for the symfony_doctrine and symfony_proxy_manager_doctrine tests, because they are coming from within the dependencies themselves and didn't find a way to fix them.