### PR TITLE
Fix tests

### DIFF
--- a/fixtures/Bridge/Doctrine/MongoDocument/DummyWithEmbeddable.php
+++ b/fixtures/Bridge/Doctrine/MongoDocument/DummyWithEmbeddable.php
@@ -28,7 +28,7 @@ class DummyWithEmbeddable
     public $id;
 
     /**
-     * @EmbedOne(targetDocument="DummyEmbeddable")
+     * @EmbedOne(targetDocument="Fidry\AliceDataFixtures\Bridge\Doctrine\MongoDocument\DummyEmbeddable")
      */
     public $embeddable;
 }


### PR DESCRIPTION
Field "embeddable" in class "Fidry\AliceDataFixtures\Bridge\Doctrine\MongoDocument\DummyWithEmbeddable"
relies on same-namespace resolution for the target document.
This is deprecated and will be dropped in doctrine/mongodb-odm 2.0. Please use a FQCN instead.