### PR TITLE
Avoid permanent change of the IdGenerator entity metadata

### DIFF
--- a/tests/Bridge/Doctrine/Persister/ObjectManagerPersisterTest.php
+++ b/tests/Bridge/Doctrine/Persister/ObjectManagerPersisterTest.php
@@ -107,7 +107,17 @@ class ObjectManagerPersisterTest extends TestCase
         $dummy->id = 200;
         $this->persister->persist($dummy);
 
+        $this->assertFalse(
+            $this->entityManager->getClassMetadata(DummyWithIdentifier::class)->usesIdGenerator(),
+            'ID generator should be changed.'
+        );
+
         $this->persister->flush();
+
+        $this->assertTrue(
+            $this->entityManager->getClassMetadata(DummyWithIdentifier::class)->usesIdGenerator(),
+            'ID generator should be restored after flush.'
+        );
 
         $entity = $this->entityManager->getRepository(DummyWithIdentifier::class)->find(200);
         $this->assertInstanceOf(DummyWithIdentifier::class, $entity);


### PR DESCRIPTION
fixes #105

In any case the generator is changed on the metadata, it must be restored afterward.

Otherwise, manual entity persistence after fixture loading will cause troubles.

Tests was added during the feature addition: https://github.com/theofidry/AliceDataFixtures/commit/7053c75de4d5a91c5bd7db43918a907706c7c990#diff-292d5068b7f30308701962493b4cfd57

So if Travis is green, that will prove the condition is not necessary.

Otherwise, we have to find an another way to deal with it, because leaving the metadata at this state is not acceptable.