### PR TITLE
Fixed deprecations for Symfony 5.1: added "package" and "version" attrs

### DIFF
--- a/src/Bridge/Symfony/Resources/config/doctrine_orm.xml
+++ b/src/Bridge/Symfony/Resources/config/doctrine_orm.xml
@@ -66,7 +66,7 @@
                  public="false">
             <factory class="Fidry\AliceDataFixtures\Persistence\PurgeMode" method="createDeleteMode" />
 
-            <deprecated>The service "%service_id%" is deprecated and will be removed in future versions. Inject the purger or purger factory directly instead.</deprecated>
+            <deprecated package="theofidry/alice-data-fixtures" version="1.0">The service "%service_id%" is deprecated and will be removed in future versions. Inject the purger or purger factory directly instead.</deprecated>
         </service>
 
 

--- a/src/Bridge/Symfony/Resources/config/doctrine_phpcr_odm.xml
+++ b/src/Bridge/Symfony/Resources/config/doctrine_phpcr_odm.xml
@@ -60,7 +60,7 @@
                  lazy="true">
             <argument type="service" id="doctrine_phpcr.odm.document_manager" />
 
-            <deprecated>The service "%service_id%s" is deprecated and will be removed in future versions. Use "fidry_alice_data_fixtures.persistence.doctrine_phpcr.purger.purger_factory" instead.</deprecated>
+            <deprecated package="theofidry/alice-data-fixtures" version="1.0">The service "%service_id%s" is deprecated and will be removed in future versions. Use "fidry_alice_data_fixtures.persistence.doctrine_phpcr.purger.purger_factory" instead.</deprecated>
         </service>
 
 

--- a/src/Bridge/Symfony/Resources/config/eloquent_orm.xml
+++ b/src/Bridge/Symfony/Resources/config/eloquent_orm.xml
@@ -72,7 +72,7 @@
                  public="false">
             <factory class="Fidry\AliceDataFixtures\Persistence\PurgeMode" method="createDeleteMode" />
 
-            <deprecated>The service "%service_id%" is deprecated and will be removed in future versions. Inject the purger or purger factory directly instead.</deprecated>
+            <deprecated package="theofidry/alice-data-fixtures" version="1.0">The service "%service_id%" is deprecated and will be removed in future versions. Inject the purger or purger factory directly instead.</deprecated>
         </service>
 
 

--- a/src/Bridge/Symfony/Resources/config/loader.xml
+++ b/src/Bridge/Symfony/Resources/config/loader.xml
@@ -19,7 +19,7 @@
                  lazy="true" >
             <argument type="service" id="nelmio_alice.file_loader" />
 
-            <deprecated>The service "%service_id%" is deprecated and will be removed in future versions.</deprecated>
+            <deprecated package="theofidry/alice-data-fixtures" version="1.0">The service "%service_id%" is deprecated and will be removed in future versions.</deprecated>
         </service>
 
         <service id="fidry_alice_data_fixtures.loader.simple"


### PR DESCRIPTION
Hi,

This little PR to fix deprecations starting with Symfony 5.1.

This fixes deprecations due to... deprecations not fully configured :D

For the package version I took the first stable release available for each deprecation, which results in 1.0.