### PR TITLE
Fix PHPUnit deprecations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /fixtures/Bridge/Propel2/Model/
 !/fixtures/Bridge/Propel2/Model/.gitkeep
 /fixtures/Bridge/Symfony/SymfonyApp/cache/*
+/var
 /phpunit.xml
 /.php_cs.cache
 /.phar/
@@ -19,3 +20,4 @@
 !/bin/doctrine_purge
 !/bin/eloquent_migrate
 !/bin/eloquent_rollback
+/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
 
 php:
   - '7.3'
-  - '7.3'
   - '7.4'
 
 branches:

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/phpunit-bridge": "^5.1.3"
     },
     "conflict": {
-        "doctrine/orm": "<2.5",
+        "doctrine/orm": "<2.6.3",
         "illuminate/database": "<5.5",
         "ocramius/proxy-manager": "<2.1",
         "symfony/framework-bundle": "<3.4",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "bamarni/composer-bin-plugin": "^1.1",
         "phpspec/prophecy": "^1.6",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": "^8.5.4 || ^9.0",
+        "phpunit/phpunit": "^9.3",
         "symfony/phpunit-bridge": "^5.1.3"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "doctrine/orm": "<2.5",
         "illuminate/database": "<5.5",
         "ocramius/proxy-manager": "<2.1",
-        "symfony/framework-bundle": "<3.4"
+        "symfony/framework-bundle": "<3.4",
+        "zendframework/zend-code": "<3.3.1"
     },
     "suggest": {
         "doctrine/data-fixtures": "To use Doctrine",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,13 +30,13 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>src</directory>
-            <exclude>
-                <directory>src/Bridge</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory>src/Bridge</directory>
+        </exclude>
+    </coverage>
 
 </phpunit>

--- a/phpunit_doctrine.xml.dist
+++ b/phpunit_doctrine.xml.dist
@@ -34,10 +34,10 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>src/Bridge/Doctrine</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 
 </phpunit>

--- a/phpunit_doctrine_mongodb.xml.dist
+++ b/phpunit_doctrine_mongodb.xml.dist
@@ -29,10 +29,10 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>src/Bridge/Doctrine</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 
 </phpunit>

--- a/phpunit_doctrine_phpcr.xml.dist
+++ b/phpunit_doctrine_phpcr.xml.dist
@@ -35,10 +35,10 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>src/Bridge/Doctrine</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 
 </phpunit>

--- a/phpunit_eloquent.xml.dist
+++ b/phpunit_eloquent.xml.dist
@@ -34,10 +34,10 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>src/Bridge/Eloquent</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 
 </phpunit>

--- a/phpunit_propel2.xml.dist
+++ b/phpunit_propel2.xml.dist
@@ -29,10 +29,10 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>src/Bridge/Propel2</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 
 </phpunit>

--- a/phpunit_symfony.xml.dist
+++ b/phpunit_symfony.xml.dist
@@ -32,13 +32,16 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>src/Bridge/Symfony</directory>
-            <exclude>tests/Bridge/Symfony/Doctrine</exclude>
-            <exclude>tests/Bridge/Symfony/Eloquent</exclude>
-            <exclude>tests/Bridge/Symfony/ProxyManager</exclude>
-        </whitelist>
-    </filter>
+        </include>
+
+        <exclude>
+            <directory>tests/Bridge/Symfony/Doctrine</directory>
+            <directory>tests/Bridge/Symfony/Eloquent</directory>
+            <directory>tests/Bridge/Symfony/ProxyManager</directory>
+        </exclude>
+    </coverage>
 
 </phpunit>

--- a/phpunit_symfony_doctrine.xml.dist
+++ b/phpunit_symfony_doctrine.xml.dist
@@ -29,10 +29,10 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>src/Bridge/Symfony/Doctrine</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 
 </phpunit>

--- a/phpunit_symfony_eloquent.xml.dist
+++ b/phpunit_symfony_eloquent.xml.dist
@@ -29,10 +29,10 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>src/Bridge/Symfony/Eloquent</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 
 </phpunit>

--- a/phpunit_symfony_proxy_manager_with_doctrine.xml.dist
+++ b/phpunit_symfony_proxy_manager_with_doctrine.xml.dist
@@ -29,10 +29,10 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>src/Bridge/Symfony/Doctrine</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 
 </phpunit>

--- a/phpunit_symfony_proxy_manager_with_eloquent.xml.dist
+++ b/phpunit_symfony_proxy_manager_with_eloquent.xml.dist
@@ -29,10 +29,10 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <includec>
             <directory>tests/Bridge/Symfony/Eloquent</directory>
-        </whitelist>
-    </filter>
+        </includec>
+    </coverage>
 
 </phpunit>

--- a/tests/Bridge/Doctrine/Purger/PurgerTest.php
+++ b/tests/Bridge/Doctrine/Purger/PurgerTest.php
@@ -23,6 +23,7 @@ use Fidry\AliceDataFixtures\Persistence\PurgeMode;
 use Fidry\AliceDataFixtures\Persistence\PurgerFactoryInterface;
 use Fidry\AliceDataFixtures\Persistence\PurgerInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -30,6 +31,8 @@ use ReflectionClass;
  */
 class PurgerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAPurger()
     {
         $this->assertTrue(is_a(Purger::class, PurgerInterface::class, true));

--- a/tests/Bridge/DoctrineMongoDB/Purger/PurgerTest.php
+++ b/tests/Bridge/DoctrineMongoDB/Purger/PurgerTest.php
@@ -18,6 +18,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Fidry\AliceDataFixtures\Bridge\Doctrine\MongoDocument\Dummy;
 use Fidry\AliceDataFixtures\Bridge\Doctrine\Purger\Purger;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @covers \Fidry\AliceDataFixtures\Bridge\Doctrine\Purger\Purger
@@ -26,6 +27,8 @@ use PHPUnit\Framework\TestCase;
  */
 class PurgerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testCreatesADoctrineOdmPurgerWithTheAppropriateManager()
     {
         $manager = $this->prophesize(DocumentManager::class)->reveal();

--- a/tests/Bridge/DoctrinePhpCr/Purger/PurgerTest.php
+++ b/tests/Bridge/DoctrinePhpCr/Purger/PurgerTest.php
@@ -22,6 +22,7 @@ use Fidry\AliceDataFixtures\Persistence\PurgeMode;
 use Fidry\AliceDataFixtures\Persistence\PurgerFactoryInterface;
 use Fidry\AliceDataFixtures\Persistence\PurgerInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 
 /**
@@ -29,6 +30,8 @@ use ReflectionClass;
  */
 class PurgerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAPurger()
     {
         $this->assertTrue(is_a(Purger::class, PurgerInterface::class, true));

--- a/tests/Bridge/Eloquent/Purger/ModelPurgerTest.php
+++ b/tests/Bridge/Eloquent/Purger/ModelPurgerTest.php
@@ -22,6 +22,7 @@ use Illuminate\Database\Migrations\MigrationRepositoryInterface;
 use Illuminate\Database\Migrations\Migrator;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionClass;
 
@@ -32,6 +33,8 @@ use ReflectionClass;
  */
 class ModelPurgerTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsAPurger()
     {
         $this->assertTrue(is_a(ModelPurger::class, PurgerInterface::class, true));

--- a/tests/Loader/FileResolverLoaderTest.php
+++ b/tests/Loader/FileResolverLoaderTest.php
@@ -18,6 +18,7 @@ use Fidry\AliceDataFixtures\FileResolverInterface;
 use Fidry\AliceDataFixtures\LoaderInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 use stdClass;
 
@@ -26,6 +27,8 @@ use stdClass;
  */
 class FileResolverLoaderTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsALoader()
     {
         $this->assertTrue(is_a(FileResolverLoader::class, LoaderInterface::class, true));

--- a/tests/Loader/MultiPassFileLoaderTest.php
+++ b/tests/Loader/MultiPassFileLoaderTest.php
@@ -25,6 +25,7 @@ use Nelmio\Alice\ParameterBag;
 use Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueDuringGenerationException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 use stdClass;
 
@@ -37,6 +38,8 @@ use stdClass;
  */
 class MultiPassFileLoaderTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsALoader()
     {
         $this->assertTrue(is_a(MultiPassLoader::class, LoaderInterface::class, true));

--- a/tests/Loader/PersisterLoaderTest.php
+++ b/tests/Loader/PersisterLoaderTest.php
@@ -20,6 +20,7 @@ use Fidry\AliceDataFixtures\Persistence\PersisterInterface;
 use Fidry\AliceDataFixtures\ProcessorInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 use stdClass;
 
@@ -28,6 +29,8 @@ use stdClass;
  */
 class PersisterLoaderTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsALoader()
     {
         $this->assertTrue(is_a(PersisterLoader::class, LoaderInterface::class, true));

--- a/tests/Loader/PurgerLoaderTest.php
+++ b/tests/Loader/PurgerLoaderTest.php
@@ -19,6 +19,7 @@ use Fidry\AliceDataFixtures\Persistence\PurgerFactoryInterface;
 use Fidry\AliceDataFixtures\Persistence\PurgerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionClass;
 use stdClass;
@@ -30,6 +31,8 @@ use stdClass;
  */
 class PurgerLoaderTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsALoader()
     {
         $this->assertTrue(is_a(PurgerLoader::class, LoaderInterface::class, true));

--- a/tests/Loader/SimpleLoaderTest.php
+++ b/tests/Loader/SimpleLoaderTest.php
@@ -20,6 +20,7 @@ use Nelmio\Alice\ObjectSet;
 use Nelmio\Alice\ParameterBag;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 use stdClass;
 
@@ -28,6 +29,8 @@ use stdClass;
  */
 class SimpleLoaderTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testIsALoader()
     {
         $this->assertTrue(is_a(SimpleLoader::class, LoaderInterface::class, true));

--- a/vendor-bin/doctrine/composer.json
+++ b/vendor-bin/doctrine/composer.json
@@ -2,6 +2,7 @@
     "require-dev": {
         "doctrine/data-fixtures": "^1.2",
         "doctrine/orm": "^2.5",
+        "doctrine/persistence": "^1.3.4",
         "theofidry/composer-inheritance-plugin": "^1.0"
     },
     "config": {

--- a/vendor-bin/doctrine_mongodb/composer.json
+++ b/vendor-bin/doctrine_mongodb/composer.json
@@ -3,6 +3,7 @@
         "alcaeus/mongo-php-adapter": "^1.1.3",
         "doctrine/data-fixtures": "^1.2",
         "doctrine/mongodb-odm": "^1.2.0",
+        "doctrine/persistence": "^1.3.4",
         "theofidry/composer-inheritance-plugin": "^1.0"
     },
     "config": {

--- a/vendor-bin/doctrine_phpcr/composer.json
+++ b/vendor-bin/doctrine_phpcr/composer.json
@@ -1,5 +1,6 @@
 {
     "require-dev": {
+        "doctrine/persistence": "^1.3.4",
         "doctrine/phpcr-odm": "^1.4",
         "jackalope/jackalope-doctrine-dbal": "^1.2",
         "symfony/console": "^2.7 || ^3.4 || ^4.0",


### PR DESCRIPTION
Replaces https://github.com/theofidry/AliceDataFixtures/pull/145, it adds @jmsche [suggestion](https://github.com/theofidry/AliceDataFixtures/pull/145#issuecomment-692077614) and requires explicitly `doctrine/persistance`.

I also added conflict with `zendframework/zend-code` < 3.3.1 because of https://github.com/zendframework/zend-code/pull/158 and with `doctrine/orm` < 2.6.3 because of https://github.com/doctrine/orm/pull/7325.