### PR TITLE
Don't disable the id generator if the entity has already been persisted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ before_install:
   - phpenv config-rm xdebug.ini || true
   - PHPUNIT_FLAGS='--stop-on-failure --verbose'
 
+  # TODO: Allow using Composer version 2 when will wikimedia/composer-merge-plugin support it too.
+  - composer self-update --1
+
 install:
   - perl -pi -e 's/^}$/,"provide":{"ext-mongo":"*"}}/' composer.json
   - composer update --prefer-dist $COMPOSER_FLAGS

--- a/src/Bridge/Doctrine/Persister/ObjectManagerPersister.php
+++ b/src/Bridge/Doctrine/Persister/ObjectManagerPersister.php
@@ -58,17 +58,19 @@ class ObjectManagerPersister implements PersisterInterface
         if (isset($this->persistableClasses[$class])) {
             $metadata = $this->objectManager->getClassMetadata($class);
 
-            // Check if the ID is explicitly set by the user. To avoid the ID to be overridden by the ID generator
-            // registered, we disable it for that specific object.
-            if ($metadata instanceof ORMClassMetadataInfo) {
-                if ($metadata->usesIdGenerator() && false === empty($metadata->getIdentifierValues($object))) {
-                    $metadata = $this->configureIdGenerator($metadata);
+            if (!$this->objectManager->contains($object)) {
+                // Unless the object is new, check if the ID is explicitly set by the user. To avoid the ID to be
+                // overridden by the ID generator registered, we disable it for that specific object.
+                if ($metadata instanceof ORMClassMetadataInfo) {
+                    if ($metadata->usesIdGenerator() && false === empty($metadata->getIdentifierValues($object))) {
+                        $metadata = $this->configureIdGenerator($metadata);
+                    }
+                } else if ($metadata instanceof ODMClassMetadataInfo) {
+                    // Do nothing: currently not supported as Doctrine ODM does not have an equivalent of the ORM
+                    // AssignedGenerator.
+                } else {
+                    // Do nothing: not supported.
                 }
-            } elseif ($metadata instanceof ODMClassMetadataInfo) {
-                // Do nothing: currently not supported as Doctrine ODM does not have an equivalent of the ORM
-                // AssignedGenerator.
-            } else {
-                // Do nothing: not supported.
             }
 
             try {


### PR DESCRIPTION
Should fix #151 