### PR TITLE
Keep the ids specified for entities by end users

### DIFF
--- a/fixtures/Bridge/Doctrine/Entity/DummyWithRelation.php
+++ b/fixtures/Bridge/Doctrine/Entity/DummyWithRelation.php
@@ -27,7 +27,7 @@ class DummyWithRelation
 
     /**
      * @var DummyWithIdentifier
-     * @OneToOne(targetEntity="Dummy", cascade={"persist"})
+     * @OneToOne(targetEntity="DummyWithIdentifier", cascade={"persist"})
      * @JoinColumn(name="dummy_id", referencedColumnName="id")
      */
     public $dummy;

--- a/fixtures/Bridge/Doctrine/Entity/DummyWithRelation.php
+++ b/fixtures/Bridge/Doctrine/Entity/DummyWithRelation.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Fidry\AliceDataFixtures package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\AliceDataFixtures\Bridge\Doctrine\Entity;
+
+/**
+ * @Entity
+ */
+class DummyWithRelation
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    public $id;
+
+    /**
+     * @var DummyWithIdentifier
+     * @OneToOne(targetEntity="Dummy", cascade={"persist"})
+     * @JoinColumn(name="dummy_id", referencedColumnName="id")
+     */
+    public $dummy;
+}

--- a/src/Bridge/Doctrine/IdGenerator.php
+++ b/src/Bridge/Doctrine/IdGenerator.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Fidry\AliceDataFixtures\Bridge\Doctrine;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Id\AbstractIdGenerator;
+
+class IdGenerator extends AbstractIdGenerator
+{
+    const GENERATOR_TYPE_ALICE = 10;
+    /**
+     * @var AbstractIdGenerator
+     */
+    private $decorated;
+
+    public function __construct(AbstractIdGenerator $decorated)
+    {
+        $this->decorated = $decorated;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function generate(EntityManager $em, $entity)
+    {
+        $class = get_class($entity);
+
+        $metadata = $em->getClassMetadata($class);
+        $idValues = $metadata->getIdentifierValues($entity);
+
+        if (is_array($idValues) && count($idValues) == 1) {
+            return reset($idValues);
+        }
+
+        return $this->decorated->generate($em, $entity);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isPostInsertGenerator()
+    {
+        return $this->decorated->isPostInsertGenerator();
+    }
+}

--- a/tests/Bridge/Doctrine/Persister/ObjectManagerPersisterTest.php
+++ b/tests/Bridge/Doctrine/Persister/ObjectManagerPersisterTest.php
@@ -22,6 +22,7 @@ use Fidry\AliceDataFixtures\Bridge\Doctrine\Entity\DummyEmbeddable;
 use Fidry\AliceDataFixtures\Bridge\Doctrine\Entity\DummySubClass;
 use Fidry\AliceDataFixtures\Bridge\Doctrine\Entity\DummyWithEmbeddable;
 use Fidry\AliceDataFixtures\Bridge\Doctrine\Entity\DummyWithIdentifier;
+use Fidry\AliceDataFixtures\Bridge\Doctrine\Entity\DummyWithRelation;
 use Fidry\AliceDataFixtures\Bridge\Doctrine\Entity\MappedSuperclassDummy;
 use Fidry\AliceDataFixtures\Exception\ObjectGeneratorPersisterException;
 use Fidry\AliceDataFixtures\Persistence\PersisterInterface;
@@ -95,6 +96,32 @@ class ObjectManagerPersisterTest extends TestCase
         if ($exact) {
             $this->assertEquals($originalEntity, $result[0]);
         }
+    }
+
+    public function testCanPersistAnEntityWithRelationsAndExplicitIds()
+    {
+        $dummy = new Dummy();
+        $dummy->id = 100;
+
+        $dummyWithRelation = new DummyWithRelation();
+        $dummyWithRelation->id = 100;
+        $dummyWithRelation->dummy = $dummy;
+
+        $this->persister->persist($dummyWithRelation);
+        $this->persister->flush();
+
+        $this->persister->persist($dummy);
+        $this->persister->flush();
+
+        $this->entityManager->clear();
+
+        $result = $this->entityManager->getRepository(get_class($dummy))->findOneBy(['id' => 100]);
+        $this->assertNotNull($result);
+        $this->assertEquals($result->id, $dummy->id);
+
+        $result = $this->entityManager->getRepository(get_class($dummyWithRelation))->findOneBy(['id' => 100]);
+        $this->assertNotNull($result);
+        $this->assertEquals($result->id, $dummyWithRelation->id);
     }
 
     public function testCanPersistMultipleEntitiesWithExplicitIdentifierSet()

--- a/tests/Bridge/Doctrine/Persister/ObjectManagerPersisterTest.php
+++ b/tests/Bridge/Doctrine/Persister/ObjectManagerPersisterTest.php
@@ -108,8 +108,6 @@ class ObjectManagerPersisterTest extends TestCase
         $dummyWithRelation->dummy = $dummy;
 
         $this->persister->persist($dummyWithRelation);
-        $this->persister->flush();
-
         $this->persister->persist($dummy);
         $this->persister->flush();
 


### PR DESCRIPTION
This should solve the problem found in #153 
It also allows to mix fixtures with and without provided ids.

@VincentLanglet would you mind to test this PR with your fixtures set?
And @yakobe could you test with yours?

I checked on my project and this works.