### PR TITLE
Fix MySQL platform detection

### DIFF
--- a/src/Bridge/Doctrine/Purger/Purger.php
+++ b/src/Bridge/Doctrine/Purger/Purger.php
@@ -17,7 +17,7 @@ use Doctrine\Common\DataFixtures\Purger\MongoDBPurger as DoctrineMongoDBPurger;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger as DoctrineOrmPurger;
 use Doctrine\Common\DataFixtures\Purger\PHPCRPurger as DoctrinePhpCrPurger;
 use Doctrine\Common\DataFixtures\Purger\PurgerInterface as DoctrinePurgerInterface;
-use Doctrine\DBAL\Driver\AbstractMySQLDriver;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\ODM\MongoDB\DocumentManager as DoctrineMongoDocumentManager;
 use Doctrine\ODM\PHPCR\DocumentManager as DoctrinePhpCrDocumentManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -98,7 +98,7 @@ use Nelmio\Alice\IsAServiceTrait;
         $disableFkChecks = (
             $this->purger instanceof DoctrineOrmPurger
             && in_array($this->purgeMode->getValue(), [PurgeMode::createDeleteMode()->getValue(), PurgeMode::createTruncateMode()->getValue()])
-            && $this->purger->getObjectManager()->getConnection()->getDriver() instanceof AbstractMySQLDriver
+            && $this->purger->getObjectManager()->getConnection()->getDatabasePlatform() instanceof MySqlPlatform
         );
 
         if ($disableFkChecks) {

--- a/tests/Bridge/Doctrine/Purger/PurgerTest.php
+++ b/tests/Bridge/Doctrine/Purger/PurgerTest.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Fidry\AliceDataFixtures\Bridge\Doctrine\Purger;
 
 use Doctrine\Common\DataFixtures\Purger\ORMPurger as DoctrineOrmPurger;
-use Doctrine\DBAL\Driver\AbstractMySQLDriver;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\ORM\EntityManager;
 use Fidry\AliceDataFixtures\Bridge\Doctrine\Entity\Dummy;
 use Fidry\AliceDataFixtures\Bridge\Doctrine\ORM\FakeEntityManager;
@@ -67,7 +67,7 @@ class PurgerTest extends TestCase
     public function testDisableFKChecksOnDeleteIsPerformed()
     {
         $connection = $this->prophesize(Connection::class);
-        $connection->getDriver()->willReturn($this->prophesize(AbstractMySQLDriver::class)->reveal());
+        $connection->getDatabasePlatform()->willReturn($this->prophesize(MySqlPlatform::class)->reveal());
         $connection->exec('SET FOREIGN_KEY_CHECKS = 0;')->shouldBeCalled();
         $connection->exec('SET FOREIGN_KEY_CHECKS = 1;')->shouldBeCalled();
 


### PR DESCRIPTION
When purging data, this library attempts to detect whether MySQL is used by checking the "driver"; if so, it temporarily disables foreign key constraints.

However, some libraries (like Sentry's Symfony bundle) decorate that driver to add functionality like tracing the SQL statements being executed.  Because these decorators do not extend from `AbstractMySQLDriver` this library fails to disable foreign key checks when decorated drivers are being used.  See https://github.com/getsentry/sentry-symfony/issues/503 for an example of this.

I propose that this library should check the **platform** instead of the **driver**.  Platforms describe **what type of database** is being used, versus the drivers which provide **how to interface with that database**.  Because we care more about the "what" and not the how, and because platforms are far less likely to be overridden/decorated, this change should avoid compatibility issues with other libraries and custom code.