### PR TITLE
Enable back various builds

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,14 +28,18 @@ jobs:
                         dependencies: lowest
                         variant: normal
                         composer-flags: '--prefer-lowest'
-#                    -   php-version: '7.4'
-#                        dependencies: highest
-#                        variant: 'symfony/symfony:"~4.4.0"'
-#                        composer-flags: ''
-#                    -   php-version: '7.4'
-#                        dependencies: highest
-#                        variant: 'symfony/symfony:"~5.3.0"'
-#                        composer-flags: ''
+                    -   php-version: '8.1'
+                        dependencies: highest
+                        variant: 'symfony/symfony:"^4.4"'
+                        composer-flags: ''
+                    -   php-version: '8.1'
+                        dependencies: highest
+                        variant: 'symfony/symfony:"^5.4"'
+                        composer-flags: ''
+                    -   php-version: '8.1'
+                        dependencies: highest
+                        variant: 'symfony/symfony:"^6.0"'
+                        composer-flags: ''
         # To keep in sync with docker-compose.yml
         services:
             mysql:
@@ -117,7 +121,7 @@ jobs:
                 run: composer bin proxy-manager update --prefer-dist --prefer-stable ${{ matrix.composer-flags }}
             -   name: Add back Symfony for ProxyManager Composer bin dependencies
                 if: matrix.variant == 'normal'
-                run: composer bin proxy-manager require --dev "symfony/symfony:^4.4.32 || ^5.4.1" --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --no-update
+                run: composer bin proxy-manager require --dev "symfony/symfony:^4.4.32 || ^5.4.1 || ^6.0.0" --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --no-update
             -   name: Add back Symfony (variant) for ProxyManager Composer bin dependencies
                 if: matrix.variant != 'normal'
                 run: composer bin proxy-manager update --dev symfony/symfony --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --no-update

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -122,7 +122,7 @@ jobs:
                 if: matrix.variant != 'normal'
                 run: composer bin proxy-manager update --dev symfony/symfony --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --no-update
             -   name: Install Symfony for ProxyManager Composer bin dependencies
-                run: composer bin proxy-manager update symfony/symfony --prefer-dist --prefer-stable ${{ matrix.composer-flags }}
+                run: composer bin proxy-manager update symfony/symfony --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --with-all-dependencies
 
             -   name: Configure Symfony (variant) Composer bin dependencies
                 if: matrix.variant != 'normal'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -122,7 +122,7 @@ jobs:
                 if: matrix.variant != 'normal'
                 run: composer bin proxy-manager update --dev symfony/symfony --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --no-update
             -   name: Install Symfony for ProxyManager Composer bin dependencies
-                run: composer bin proxy-manager update --prefer-dist --prefer-stable ${{ matrix.composer-flags }}
+                run: composer bin proxy-manager update symfony/symfony --prefer-dist --prefer-stable ${{ matrix.composer-flags }}
 
             -   name: Configure Symfony (variant) Composer bin dependencies
                 if: matrix.variant != 'normal'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -127,7 +127,7 @@ jobs:
                 run: composer bin proxy-manager require --dev "symfony/symfony:^4.4.32 || ^5.4.1 || ^6.0.0" --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --no-update
             -   name: Add back Symfony (variant) for ProxyManager Composer bin dependencies
                 if: matrix.variant != 'normal'
-                run: composer bin proxy-manager require --dev symfony/symfony --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --no-update
+                run: composer bin proxy-manager require --dev ${{ matrix.variant }} --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --no-update
             -   name: Install Symfony for ProxyManager Composer bin dependencies
                 run: composer bin proxy-manager update --prefer-dist --prefer-stable ${{ matrix.composer-flags }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,15 +31,15 @@ jobs:
 #                        dependencies: lowest
 #                        variant: normal
 #                        composer-flags: '--prefer-lowest'
-                    -   php-version: '8.1'
+                    -   php-version: '7.4'
                         dependencies: highest
                         variant: 'symfony/symfony:"^4.4"'
                         composer-flags: ''
-                    -   php-version: '8.1'
+                    -   php-version: '8.0'
                         dependencies: highest
                         variant: 'symfony/symfony:"^5.4"'
                         composer-flags: ''
-                    -   php-version: '8.1'
+                    -   php-version: '8.0'
                         dependencies: highest
                         variant: 'symfony/symfony:"^6.0"'
                         composer-flags: ''

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,11 +23,11 @@ jobs:
                     - '8.1'
                 dependencies: [ highest ]
                 variant: [ normal ]
-#                include:
-#                    -   php-version: '7.4'
-#                        dependencies: lowest
-#                        variant: normal
-#                        composer-flags: '--prefer-lowest'
+                include:
+                    -   php-version: '7.4'
+                        dependencies: lowest
+                        variant: normal
+                        composer-flags: '--prefer-lowest'
 #                    -   php-version: '7.4'
 #                        dependencies: highest
 #                        variant: 'symfony/symfony:"~4.4.0"'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -117,10 +117,10 @@ jobs:
                 run: composer bin proxy-manager update --prefer-dist --prefer-stable ${{ matrix.composer-flags }}
             -   name: Install Symfony for ProxyManager Composer bin dependencies
                 if: matrix.variant == 'normal'
-                run: composer bin proxy-manager require --dev "symfony/symfony:^4.4.32 || ^5.3.9" --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --with-dependencies
+                run: composer bin proxy-manager require --dev "symfony/symfony:^4.4.32 || ^5.3.9" --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --with-all-dependencies
             -   name: Install Symfony (variant) for ProxyManager Composer bin dependencies
                 if: matrix.variant != 'normal'
-                run: composer bin proxy-manager require --dev ${{ matrix.variant }} --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --with-dependencies
+                run: composer bin proxy-manager require --dev ${{ matrix.variant }} --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --with-all-dependencies
 
             -   name: Configure Symfony (variant) Composer bin dependencies
                 if: matrix.variant != 'normal'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,22 +27,25 @@ jobs:
                     # This one is excluded for now as horribly slow (the
                     # Composer update takes over 10min in the CI)
                     # This is likely due to some Symfony conflicting rules
+                    # TODO: investigate the issue and report it to Composer/Symfony
 #                    -   php-version: '7.4'
 #                        dependencies: lowest
 #                        variant: normal
 #                        composer-flags: '--prefer-lowest'
-                    -   php-version: '7.4'
-                        dependencies: highest
-                        variant: 'symfony/symfony:"^4.4"'
+                    # TODO: need more work
+#                    -   php-version: '7.4'
+#                        dependencies: highest
+#                        variant: 'symfony/symfony:"^4.4"'
                         composer-flags: ''
-                    -   php-version: '8.0'
+                    -   php-version: '7.4'
                         dependencies: highest
                         variant: 'symfony/symfony:"^5.4"'
                         composer-flags: ''
-                    -   php-version: '8.0'
-                        dependencies: highest
-                        variant: 'symfony/symfony:"^6.0"'
-                        composer-flags: ''
+                    # TODO: Should be enabled as soon as PsyshBundle supports Symfony 6.x
+#                    -   php-version: '8.1'
+#                        dependencies: highest
+#                        variant: 'symfony/symfony:"^6.0"'
+#                        composer-flags: ''
         # To keep in sync with docker-compose.yml
         services:
             mysql:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -117,10 +117,10 @@ jobs:
                 run: composer bin proxy-manager update --prefer-dist --prefer-stable ${{ matrix.composer-flags }}
             -   name: Install Symfony for ProxyManager Composer bin dependencies
                 if: matrix.variant == 'normal'
-                run: composer bin proxy-manager require --dev "symfony/symfony:^4.4.32 || ^5.4.1" --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --with-all-dependencies
+                run: composer bin proxy-manager require --dev "symfony/symfony:^4.4.32 || ^5.4.1" --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --no-update
             -   name: Install Symfony (variant) for ProxyManager Composer bin dependencies
                 if: matrix.variant != 'normal'
-                run: composer bin proxy-manager require --dev ${{ matrix.variant }} --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --with-all-dependencies
+                run: composer bin proxy-manager update --dev symfony/symfony --prefer-dist --prefer-stable ${{ matrix.composer-flags }}
 
             -   name: Configure Symfony (variant) Composer bin dependencies
                 if: matrix.variant != 'normal'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,10 +24,13 @@ jobs:
                 dependencies: [ highest ]
                 variant: [ normal ]
                 include:
-                    -   php-version: '7.4'
-                        dependencies: lowest
-                        variant: normal
-                        composer-flags: '--prefer-lowest'
+                    # This one is excluded for now as horribly slow (the
+                    # Composer update takes over 10min in the CI)
+                    # This is likely due to some Symfony conflicting rules
+#                    -   php-version: '7.4'
+#                        dependencies: lowest
+#                        variant: normal
+#                        composer-flags: '--prefer-lowest'
                     -   php-version: '8.1'
                         dependencies: highest
                         variant: 'symfony/symfony:"^4.4"'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,7 +36,7 @@ jobs:
 #                    -   php-version: '7.4'
 #                        dependencies: highest
 #                        variant: 'symfony/symfony:"^4.4"'
-                        composer-flags: ''
+#                        composer-flags: ''
                     -   php-version: '7.4'
                         dependencies: highest
                         variant: 'symfony/symfony:"^5.4"'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -115,12 +115,14 @@ jobs:
                 run: composer bin proxy-manager update --prefer-dist --prefer-stable ${{ matrix.composer-flags }}
             -   name: Repeat "Install ProxyManager Composer bin dependencies"
                 run: composer bin proxy-manager update --prefer-dist --prefer-stable ${{ matrix.composer-flags }}
-            -   name: Install Symfony for ProxyManager Composer bin dependencies
+            -   name: Add back Symfony for ProxyManager Composer bin dependencies
                 if: matrix.variant == 'normal'
                 run: composer bin proxy-manager require --dev "symfony/symfony:^4.4.32 || ^5.4.1" --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --no-update
-            -   name: Install Symfony (variant) for ProxyManager Composer bin dependencies
+            -   name: Add back Symfony (variant) for ProxyManager Composer bin dependencies
                 if: matrix.variant != 'normal'
-                run: composer bin proxy-manager update --dev symfony/symfony --prefer-dist --prefer-stable ${{ matrix.composer-flags }}
+                run: composer bin proxy-manager update --dev symfony/symfony --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --no-update
+            -   name: Install Symfony for ProxyManager Composer bin dependencies
+                run: composer bin proxy-manager update --prefer-dist --prefer-stable ${{ matrix.composer-flags }}
 
             -   name: Configure Symfony (variant) Composer bin dependencies
                 if: matrix.variant != 'normal'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -127,7 +127,7 @@ jobs:
                 run: composer bin proxy-manager require --dev "symfony/symfony:^4.4.32 || ^5.4.1 || ^6.0.0" --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --no-update
             -   name: Add back Symfony (variant) for ProxyManager Composer bin dependencies
                 if: matrix.variant != 'normal'
-                run: composer bin proxy-manager update --dev symfony/symfony --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --no-update
+                run: composer bin proxy-manager require --dev symfony/symfony --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --no-update
             -   name: Install Symfony for ProxyManager Composer bin dependencies
                 run: composer bin proxy-manager update --prefer-dist --prefer-stable ${{ matrix.composer-flags }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -122,7 +122,7 @@ jobs:
                 if: matrix.variant != 'normal'
                 run: composer bin proxy-manager update --dev symfony/symfony --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --no-update
             -   name: Install Symfony for ProxyManager Composer bin dependencies
-                run: composer bin proxy-manager update symfony/symfony --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --with-all-dependencies
+                run: composer bin proxy-manager update --prefer-dist --prefer-stable ${{ matrix.composer-flags }}
 
             -   name: Configure Symfony (variant) Composer bin dependencies
                 if: matrix.variant != 'normal'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -117,7 +117,7 @@ jobs:
                 run: composer bin proxy-manager update --prefer-dist --prefer-stable ${{ matrix.composer-flags }}
             -   name: Install Symfony for ProxyManager Composer bin dependencies
                 if: matrix.variant == 'normal'
-                run: composer bin proxy-manager require --dev "symfony/symfony:^4.4.32 || ^5.3.9" --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --with-all-dependencies
+                run: composer bin proxy-manager require --dev "symfony/symfony:^4.4.32 || ^5.4.1" --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --with-all-dependencies
             -   name: Install Symfony (variant) for ProxyManager Composer bin dependencies
                 if: matrix.variant != 'normal'
                 run: composer bin proxy-manager require --dev ${{ matrix.variant }} --prefer-dist --prefer-stable ${{ matrix.composer-flags }} --with-all-dependencies

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "doctrine/persistence": "<2.0",
         "illuminate/database": "<8.12",
         "ocramius/proxy-manager": "<2.1",
-        "symfony/framework-bundle": "<4.4 || >5.0,<5.3",
+        "symfony/framework-bundle": "<4.4 || >5.0,<5.4",
         "zendframework/zend-code": "<3.3.1"
     },
     "suggest": {

--- a/vendor-bin/proxy-manager/composer.json
+++ b/vendor-bin/proxy-manager/composer.json
@@ -16,7 +16,6 @@
         "jackalope/jackalope-doctrine-dbal": "^1.7.1",
         "ocramius/proxy-manager": "^2.13",
         "psy/psysh": "^0.10.9",
-        "symfony/symfony": "^4.4.32 || ^5.3.9",
         "theofidry/composer-inheritance-plugin": "^1.2",
         "theofidry/psysh-bundle": "^4.4",
         "wouterj/eloquent-bundle": "^2.1.1"

--- a/vendor-bin/proxy-manager/composer.json
+++ b/vendor-bin/proxy-manager/composer.json
@@ -16,6 +16,7 @@
         "jackalope/jackalope-doctrine-dbal": "^1.7.1",
         "ocramius/proxy-manager": "^2.13",
         "psy/psysh": "^0.10.9",
+        "symfony/symfony": "^4.4.32 || ^5.4.1 || ^6.0",
         "theofidry/composer-inheritance-plugin": "^1.2",
         "theofidry/psysh-bundle": "^4.4",
         "wouterj/eloquent-bundle": "^2.1.1"

--- a/vendor-bin/symfony/composer.json
+++ b/vendor-bin/symfony/composer.json
@@ -28,8 +28,5 @@
     "replace": {
         "symfony/polyfill-php72": "*",
         "symfony/polyfill-php73": "*"
-    },
-    "require": {
-        "symfony/doctrine-messenger": "^5.3"
     }
 }

--- a/vendor-bin/symfony/composer.json
+++ b/vendor-bin/symfony/composer.json
@@ -4,6 +4,9 @@
             "../../migrations"
         ]
     },
+    "require": {
+        "symfony/doctrine-messenger": "^4.4 || ^5.4 || ^6.0"
+    },
     "require-dev": {
         "alcaeus/mongo-php-adapter": "^1.2.1",
         "doctrine/data-fixtures": "^1.5.1",


### PR DESCRIPTION
Some builds still require more work, but I will not wait on them for tagging the release as I am not sure how much more work it will require and I am needed elsewhere