### PR TITLE
Fix persisting entity with nullable ManyToOne relation

### DIFF
--- a/fixtures/Bridge/Doctrine/Entity/DummyWithRelatedCascadePersist.php
+++ b/fixtures/Bridge/Doctrine/Entity/DummyWithRelatedCascadePersist.php
@@ -41,6 +41,11 @@ class DummyWithRelatedCascadePersist
     public Dummy $related;
 
     /**
+     * @ManyToOne(targetEntity="Dummy", cascade={"persist"})
+     */
+    public ?Dummy $relatedNullable = null;
+
+    /**
      * @var Collection<AnotherDummy>
      * @ManyToMany(targetEntity=AnotherDummy::class, cascade={"persist"})
      * @JoinTable(

--- a/src/Bridge/Doctrine/Persister/ObjectManagerPersister.php
+++ b/src/Bridge/Doctrine/Persister/ObjectManagerPersister.php
@@ -154,7 +154,7 @@ class ObjectManagerPersister implements PersisterInterface
                 foreach ($fieldValueOrFieldValues->getValues() as $fieldValue) {
                     $this->getMetadata($targetEntityClassName, $fieldValue);
                 }
-            } else {
+            } elseif ($fieldValueOrFieldValues !== null) {
                 $this->getMetadata($targetEntityClassName, $fieldValueOrFieldValues);
             }
         }


### PR DESCRIPTION
Fixes the error introduced in #198 (and release 1.5.0) during persisting an entity with a nullable ManyToOne relation:
```
TypeError: Fidry\AliceDataFixtures\Bridge\Doctrine\Persister\ObjectManagerPersister::getMetadata(): Argument #2 ($object) must be of type object, null given, called in src/Bridge/Doctrine/Persister/ObjectManagerPersister.php on line 158
```

See failed build with the test without fix: https://github.com/javer/AliceDataFixtures/actions/runs/1607767589
And successful build with the test and fix: https://github.com/javer/AliceDataFixtures/actions/runs/1607777714