### PR TITLE
fix(persister): added condition to check if entity values are array

### DIFF
--- a/src/Bridge/Doctrine/Persister/ObjectManagerPersister.php
+++ b/src/Bridge/Doctrine/Persister/ObjectManagerPersister.php
@@ -154,6 +154,10 @@ class ObjectManagerPersister implements PersisterInterface
                 foreach ($fieldValueOrFieldValues->getValues() as $fieldValue) {
                     $this->getMetadata($targetEntityClassName, $fieldValue);
                 }
+            } elseif (is_array($fieldValueOrFieldValues)){
+                foreach ($fieldValueOrFieldValues as $fieldValue) {
+                    $this->getMetadata($targetEntityClassName, $fieldValue);
+                }
             } elseif ($fieldValueOrFieldValues !== null) {
                 $this->getMetadata($targetEntityClassName, $fieldValueOrFieldValues);
             }

--- a/src/Bridge/Doctrine/Persister/ObjectManagerPersister.php
+++ b/src/Bridge/Doctrine/Persister/ObjectManagerPersister.php
@@ -154,7 +154,7 @@ class ObjectManagerPersister implements PersisterInterface
                 foreach ($fieldValueOrFieldValues->getValues() as $fieldValue) {
                     $this->getMetadata($targetEntityClassName, $fieldValue);
                 }
-            } elseif (is_array($fieldValueOrFieldValues)){
+            } elseif (is_array($fieldValueOrFieldValues)) {
                 foreach ($fieldValueOrFieldValues as $fieldValue) {
                     $this->getMetadata($targetEntityClassName, $fieldValue);
                 }


### PR DESCRIPTION
I had the same issue here: https://github.com/theofidry/AliceDataFixtures/issues/202
It was working well until I update the library.


## Error context:
```
TypeError : Argument 2 passed to Fidry\AliceDataFixtures\Bridge\Doctrine\Persister\ObjectManagerPersister::getMetadata() must be an object, array given
```

I defined the relationship datatype as array and not as Collection or ArrayCollection.

```php
    /**
     * @var Instance[]
     * @ORM\OneToMany(targetEntity=Instance::class, mappedBy="strategy")
     */
    public $instances = [];
```

It seems that if you didn't specify the datatype as Collection or ArrayCollection, the library loads it as array, and after in inner checks It only checks if it's a Collection, otherwise threats it as a Object, so it throws a `TypeError`.

## What I did
I added a check if it is an array, and processed it like if it was a Collection.

For me it is working, hope it helps.



