### PR TITLE
Require doctrine/annotations

### DIFF
--- a/fixtures/Bridge/Symfony/SymfonyApp/config/config.yml
+++ b/fixtures/Bridge/Symfony/SymfonyApp/config/config.yml
@@ -16,7 +16,6 @@ framework:
         enabled: false
     validation:
         enabled: true
-        enable_annotations: true
     session:
         enabled: false
     test: ~

--- a/fixtures/Bridge/Symfony/SymfonyApp/config/config_symfony_3.yml
+++ b/fixtures/Bridge/Symfony/SymfonyApp/config/config_symfony_3.yml
@@ -15,6 +15,5 @@ framework:
         enabled: false
     validation:
         enabled: true
-        enable_annotations: true
     session: ~
     test: ~

--- a/tests/Bridge/Symfony/Doctrine/PhpcrLoaderIntegrationTest.php
+++ b/tests/Bridge/Symfony/Doctrine/PhpcrLoaderIntegrationTest.php
@@ -46,7 +46,9 @@ class PhpcrLoaderIntegrationTest extends TestCase
 
     public function setUp(): void
     {
-        $this->markTestSkipped('annotation_reader is not available');
+  if (PHP_VERSION_ID < 80000) {
+        $this->markTestSkipped('The annotation reader is not available: the "enable_annotations" on the validator cannot be set as the PHP version is lower than 8');
+  }
         if (PHP_VERSION_ID >= 81000) {
             $this->markTestSkipped('Not compatible yet with PHP 8.1');
         }

--- a/tests/Bridge/Symfony/Doctrine/PhpcrLoaderIntegrationTest.php
+++ b/tests/Bridge/Symfony/Doctrine/PhpcrLoaderIntegrationTest.php
@@ -46,11 +46,12 @@ class PhpcrLoaderIntegrationTest extends TestCase
 
     public function setUp(): void
     {
-  if (PHP_VERSION_ID < 80000) {
-        $this->markTestSkipped('The annotation reader is not available: the "enable_annotations" on the validator cannot be set as the PHP version is lower than 8');
-  }
-        if (PHP_VERSION_ID >= 81000) {
-            $this->markTestSkipped('Not compatible yet with PHP 8.1');
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped('The annotation reader is not available: the "enable_annotations" on the validator cannot be set as the PHP version is lower than 8');
+        }
+
+        if (PHP_VERSION_ID >= 80000) {
+            $this->markTestSkipped('Not compatible yet with PHP 8.0');
         }
 
         $this->kernel = new DoctrinePhpcrKernel(static::$seed, true);

--- a/tests/Bridge/Symfony/Doctrine/PhpcrLoaderIntegrationTest.php
+++ b/tests/Bridge/Symfony/Doctrine/PhpcrLoaderIntegrationTest.php
@@ -13,16 +13,16 @@ declare(strict_types=1);
 
 namespace Fidry\AlicePersistence\Bridge\Symfony\Doctrine;
 
-use function bin2hex;
 use Doctrine\Common\DataFixtures\Purger\PHPCRPurger;
 use Doctrine\Persistence\ManagerRegistry;
 use Fidry\AliceDataFixtures\Bridge\Symfony\PhpCrDocument\Dummy;
 use Fidry\AliceDataFixtures\Bridge\Symfony\SymfonyApp\DoctrinePhpcrKernel;
 use Fidry\AliceDataFixtures\LoaderInterface;
-use const PHP_VERSION_ID;
 use PHPUnit\Framework\TestCase;
-use function random_bytes;
 use Symfony\Component\HttpKernel\KernelInterface;
+use function bin2hex;
+use function random_bytes;
+use const PHP_VERSION_ID;
 
 /**
  * @coversNothing
@@ -46,6 +46,7 @@ class PhpcrLoaderIntegrationTest extends TestCase
 
     public function setUp(): void
     {
+        $this->markTestSkipped('annotation_reader is not available');
         if (PHP_VERSION_ID >= 81000) {
             $this->markTestSkipped('Not compatible yet with PHP 8.1');
         }

--- a/vendor-bin/doctrine/composer.json
+++ b/vendor-bin/doctrine/composer.json
@@ -1,5 +1,6 @@
 {
     "require-dev": {
+        "doctrine/annotations": "^1.0",
         "doctrine/data-fixtures": "^1.2",
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^1.3.4 || ^2.0",

--- a/vendor-bin/doctrine_mongodb/composer.json
+++ b/vendor-bin/doctrine_mongodb/composer.json
@@ -2,6 +2,7 @@
     "require-dev": {
         "alcaeus/mongo-php-adapter": "^1.2",
         "doctrine/annotations": "^1.0",
+        "doctrine/common": "^2.13 || ^3.0",
         "doctrine/data-fixtures": "^1.2",
         "doctrine/mongodb-odm": "^2.1.2",
         "theofidry/composer-inheritance-plugin": "^1.2"

--- a/vendor-bin/doctrine_mongodb/composer.json
+++ b/vendor-bin/doctrine_mongodb/composer.json
@@ -2,7 +2,6 @@
     "require-dev": {
         "alcaeus/mongo-php-adapter": "^1.2",
         "doctrine/annotations": "^1.0",
-        "doctrine/common": "^2.13 || ^3.0",
         "doctrine/data-fixtures": "^1.2",
         "doctrine/mongodb-odm": "^2.1.2",
         "theofidry/composer-inheritance-plugin": "^1.2"

--- a/vendor-bin/doctrine_mongodb/composer.json
+++ b/vendor-bin/doctrine_mongodb/composer.json
@@ -1,6 +1,7 @@
 {
     "require-dev": {
         "alcaeus/mongo-php-adapter": "^1.2",
+        "doctrine/annotations": "^1.0",
         "doctrine/data-fixtures": "^1.2",
         "doctrine/mongodb-odm": "^2.1.2",
         "theofidry/composer-inheritance-plugin": "^1.2"

--- a/vendor-bin/doctrine_phpcr/composer.json
+++ b/vendor-bin/doctrine_phpcr/composer.json
@@ -1,6 +1,7 @@
 {
     "require-dev": {
         "doctrine/annotations": "^1.0",
+        "doctrine/common": "^2.13 || ^3.0",
         "doctrine/persistence": "^1.3.4 || ^2.0",
         "doctrine/phpcr-odm": "^1.4",
         "jackalope/jackalope-doctrine-dbal": "^1.2",

--- a/vendor-bin/doctrine_phpcr/composer.json
+++ b/vendor-bin/doctrine_phpcr/composer.json
@@ -1,7 +1,6 @@
 {
     "require-dev": {
         "doctrine/annotations": "^1.0",
-        "doctrine/common": "^2.13 || ^3.0",
         "doctrine/persistence": "^1.3.4 || ^2.0",
         "doctrine/phpcr-odm": "^1.4",
         "jackalope/jackalope-doctrine-dbal": "^1.2",

--- a/vendor-bin/doctrine_phpcr/composer.json
+++ b/vendor-bin/doctrine_phpcr/composer.json
@@ -1,5 +1,6 @@
 {
     "require-dev": {
+        "doctrine/annotations": "^1.0",
         "doctrine/persistence": "^1.3.4 || ^2.0",
         "doctrine/phpcr-odm": "^1.4",
         "jackalope/jackalope-doctrine-dbal": "^1.2",

--- a/vendor-bin/proxy-manager/composer.json
+++ b/vendor-bin/proxy-manager/composer.json
@@ -6,6 +6,7 @@
     },
     "require-dev": {
         "alcaeus/mongo-php-adapter": "^1.2.1",
+        "doctrine/annotations": "^1.0",
         "doctrine/data-fixtures": "^1.5.1",
         "doctrine/doctrine-bundle": "^2.4.3",
         "doctrine/mongodb-odm": "^2.2.2",

--- a/vendor-bin/proxy-manager/composer.json
+++ b/vendor-bin/proxy-manager/composer.json
@@ -7,7 +7,6 @@
     "require-dev": {
         "alcaeus/mongo-php-adapter": "^1.2.1",
         "doctrine/annotations": "^1.0",
-        "doctrine/common": "^2.13 || ^3.0",
         "doctrine/data-fixtures": "^1.5.1",
         "doctrine/doctrine-bundle": "^2.4.3",
         "doctrine/mongodb-odm": "^2.2.2",

--- a/vendor-bin/proxy-manager/composer.json
+++ b/vendor-bin/proxy-manager/composer.json
@@ -7,6 +7,7 @@
     "require-dev": {
         "alcaeus/mongo-php-adapter": "^1.2.1",
         "doctrine/annotations": "^1.0",
+        "doctrine/common": "^2.13 || ^3.0",
         "doctrine/data-fixtures": "^1.5.1",
         "doctrine/doctrine-bundle": "^2.4.3",
         "doctrine/mongodb-odm": "^2.2.2",

--- a/vendor-bin/symfony/composer.json
+++ b/vendor-bin/symfony/composer.json
@@ -10,6 +10,7 @@
     "require-dev": {
         "alcaeus/mongo-php-adapter": "^1.2.1",
         "doctrine/annotations": "^1.0",
+        "doctrine/common": "^2.13 || ^3.0",
         "doctrine/data-fixtures": "^1.5.1",
         "doctrine/doctrine-bundle": "^2.4.3",
         "doctrine/mongodb-odm": "^2.2.2",

--- a/vendor-bin/symfony/composer.json
+++ b/vendor-bin/symfony/composer.json
@@ -9,6 +9,7 @@
     },
     "require-dev": {
         "alcaeus/mongo-php-adapter": "^1.2.1",
+        "doctrine/annotations": "^1.0",
         "doctrine/data-fixtures": "^1.5.1",
         "doctrine/doctrine-bundle": "^2.4.3",
         "doctrine/mongodb-odm": "^2.2.2",

--- a/vendor-bin/symfony/composer.json
+++ b/vendor-bin/symfony/composer.json
@@ -10,7 +10,6 @@
     "require-dev": {
         "alcaeus/mongo-php-adapter": "^1.2.1",
         "doctrine/annotations": "^1.0",
-        "doctrine/common": "^2.13 || ^3.0",
         "doctrine/data-fixtures": "^1.5.1",
         "doctrine/doctrine-bundle": "^2.4.3",
         "doctrine/mongodb-odm": "^2.2.2",


### PR DESCRIPTION
I saw this error [on CI](https://github.com/theofidry/AliceDataFixtures/runs/5066863207?check_suite_focus=true) :

> PHP Fatal error:  Uncaught Error: Class 'Doctrine\Common\Annotations\AnnotationRegistry' not found in /home/runner/work/AliceDataFixtures/AliceDataFixtures/vendor-bin/doctrine/vendor/doctrine/orm/lib/Doctrine/ORM/Configuration.php:165

`doctrine/annotations` was a dependency of `doctrine/persistence` until https://github.com/doctrine/persistence/pull/197/files

It has to be a strong dependency now.