### PR TITLE
[PHP 8] Comply with Doctrine's deprecation notice

### DIFF
--- a/src/Bridge/Doctrine/IdGenerator.php
+++ b/src/Bridge/Doctrine/IdGenerator.php
@@ -32,7 +32,7 @@ class IdGenerator extends AbstractIdGenerator
         $this->decorated = $decorated;
     }
 
-    public function generate(EntityManager $em, $entity)
+    public function generate(EntityManager $em, $entity): mixed
     {
         Assert::notNull($entity);
 


### PR DESCRIPTION
> ⚠ **BREAKING** — PHP 8 [ONLY](https://php.watch/versions/8.0/mixed-type) ⚠

Removes the following deprecation notice :

```
User Deprecated: Method "Doctrine\ORM\Id\AbstractIdGenerator::generate()" might add "mixed" as a native return type declaration in the future. Do the same in child class "Fidry\AliceDataFixtures\Bridge\Doctrine\IdGenerator" now
```

