### PR TITLE
ci: Do not install PHP-CS-Fixer

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -127,9 +127,6 @@ jobs:
             -   name: Repeat "Install Symfony Composer bin dependencies"
                 run: composer bin symfony update --prefer-dist --prefer-stable ${{ matrix.composer-flags }}
 
-            -   name: Install PHP-CS-Fixer Composer bin dependencies
-                run: composer bin php-cs-fixer install --prefer-dist
-
             -   name: Run Tests
                 run: make test
                 timeout-minutes: 5


### PR DESCRIPTION
PHP-CS-Fixer is not executed in the CI hence there is no point installing it there.