### PR TITLE
ci: Migrate from mongo to mongosh

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,7 +40,7 @@ jobs:
                     MYSQL_ROOT_USER: root
                     MYSQL_ROOT_PASSWORD: password
             mongo:
-                image: mongo:4.4-bionic
+                image: mongo:7.0-bionic
                 ports:
                     - 27018:27017
                 env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ jobs:
                     MYSQL_DATABASE: fidry_alice_data_fixtures
                     MYSQL_ROOT_USER: root
                     MYSQL_ROOT_PASSWORD: password
-            mongosh:
+            mongo:
                 image: mongo:4.4-bionic
                 ports:
                     - 27018:27017

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,6 +12,7 @@ on:
 env:
     MYSQL_HOST: '127.0.0.1'
     DOCTRINE_ORM_DB_HOST: '127.0.0.1'
+    MONGO_DB_VERSION: '7.0'
     XDEBUG_MODE: 'coverage'
 
 jobs:
@@ -55,13 +56,12 @@ jobs:
                 run: |
                     sudo apt-get update
                     sudo apt-get install -y wget gnupg
-                    wget -qO - https://www.mongodb.org/static/pgp/server-7.0.asc | sudo apt-key add -
-                    echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-7.0.list
+                    wget -qO - https://www.mongodb.org/static/pgp/server-${MONGO_DB_VERSION}.asc | sudo apt-key add -
+                    echo \
+                        "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/${MONGO_DB_VERSION} multiverse" \
+                        | sudo tee /etc/apt/sources.list.d/mongodb-org-${MONGO_DB_VERSION}.list
                     sudo apt-get update
                     sudo apt-get install -y mongodb-mongosh
-
-            -   name: Debug
-                run: mongosh --version
 
             -   name: Install PHP with extensions
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,7 +56,7 @@ jobs:
                     sudo apt-get update
                     sudo apt-get install -y wget gnupg
                     wget -qO - https://www.mongodb.org/static/pgp/server-7.0.asc | sudo apt-key add -
-                    echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
+                    echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-7.0.list
                     sudo apt-get update
                     sudo apt-get install -y mongodb-mongosh
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,6 +51,9 @@ jobs:
             -   name: Checkout
                 uses: actions/checkout@v4
 
+            -   name: Debug
+                run: mongosh --version
+
             -   name: Install PHP with extensions
                 uses: shivammathur/setup-php@v2
                 with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,7 +40,7 @@ jobs:
                     MYSQL_ROOT_USER: root
                     MYSQL_ROOT_PASSWORD: password
             mongo:
-                image: mongo:7.0-bionic
+                image: mongo:7.0
                 ports:
                     - 27018:27017
                 env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,6 +51,15 @@ jobs:
             -   name: Checkout
                 uses: actions/checkout@v4
 
+            -   name: Install mongosh
+                run: |
+                    sudo apt-get update
+                    sudo apt-get install -y wget gnupg
+                    wget -qO - https://www.mongodb.org/static/pgp/server-7.0.asc | sudo apt-key add -
+                    echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
+                    sudo apt-get update
+                    sudo apt-get install -y mongodb-mongosh
+
             -   name: Debug
                 run: mongosh --version
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ jobs:
                     MYSQL_DATABASE: fidry_alice_data_fixtures
                     MYSQL_ROOT_USER: root
                     MYSQL_ROOT_PASSWORD: password
-            mongo:
+            mongosh:
                 image: mongo:4.4-bionic
                 ports:
                     - 27018:27017

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ help:
 .PHONY: clean
 clean:			## Removes all created artefacts
 clean:
-	$(MYSQL_BIN) -e "DROP DATABASE IF EXISTS fidry_alice_data_fixtures;"
-	$(MONGO_BIN) --eval "db.getMongo().getDBNames().forEach(function(i){db.getSiblingDB(i).dropDatabase()})"
+	$(MYSQL_BIN) --execute="DROP DATABASE IF EXISTS fidry_alice_data_fixtures;"
+	$(MAKE) refresh_mongodb_db
 
 	git clean --exclude=.idea/ -ffdx
 
@@ -37,7 +37,7 @@ refresh_mysql_db:
 .PHONY: refresh_mongodb_db
 refresh_mongodb_db:	## Refresh the MongoDB database used
 refresh_mongodb_db:
-	$(MONGO_BIN) --eval "db.getMongo().getDBNames().forEach(function(i){db.getSiblingDB(i).dropDatabase()})"
+	$(MONGO_BIN) --eval "db.getMongo().getDBNames().filter(dbName => !['admin', 'config', 'local'].includes(dbName)).forEach(dbName => db.getSiblingDB(dbName).dropDatabase())"
 
 .PHONY: refresh_phpcr
 refresh_phpcr:		## Refresh the MongoDB PHPCR database used

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 PHP_CS_FIXER=php -d zend.enable_gc=0 vendor-bin/php-cs-fixer/bin/php-cs-fixer
 DOCKER_COMPOSE=docker-compose
-DOCKER_COMPOSE_EXEC=$(DOCKER_COMPOSE) exec -T
+DOCKER_COMPOSE_EXEC=$(DOCKER_COMPOSE) exec --no-TTY
 ifeq ("$(CI)", "true")
 MYSQL_BIN=mysql --user=root --password=password --port=3307
 MONGO_BIN=mongosh --username=root --password=password --port=27018
 else
 MYSQL_BIN=$(DOCKER_COMPOSE_EXEC) mysql mysql --user=root --password=password --port=3307
-MONGO_BIN=$(DOCKER_COMPOSE_EXEC) mongo mongo --username=root --password=password --port=27017
+MONGO_BIN=$(DOCKER_COMPOSE_EXEC) mongo mongosh --username=root --password=password --port=27017
 endif
 
 .DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DOCKER_COMPOSE=docker-compose
 DOCKER_COMPOSE_EXEC=$(DOCKER_COMPOSE) exec -T
 ifeq ("$(CI)", "true")
 MYSQL_BIN=mysql --user=root --password=password --port=3307
-MONGO_BIN=mongo --username=root --password=password --port=27018
+MONGO_BIN=mongosh --username=root --password=password --port=27018
 else
 MYSQL_BIN=$(DOCKER_COMPOSE_EXEC) mysql mysql --user=root --password=password --port=3307
 MONGO_BIN=$(DOCKER_COMPOSE_EXEC) mongo mongo --username=root --password=password --port=27017

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
             - /var/lib/mysql
 
     mongo:
-        image: mongo:4.4-bionic
+        image: mongo:7.0
         ports:
             - 27018:27017
         environment:


### PR DESCRIPTION
Starting from Mongodb version 6.0 mongo was replaced by mongosh
