### PR TITLE
chore: Remove unnecessary constraints

### DIFF
--- a/vendor-bin/doctrine/composer.json
+++ b/vendor-bin/doctrine/composer.json
@@ -1,11 +1,11 @@
 {
     "require-dev": {
-        "doctrine/annotations": "^1.0",
-        "doctrine/data-fixtures": "^1.2",
-        "doctrine/orm": "^2.5",
-        "doctrine/persistence": "^1.3.4 || ^2.0",
+        "doctrine/annotations": "*",
+        "doctrine/data-fixtures": "*",
+        "doctrine/orm": "*",
+        "doctrine/persistence": "*",
         "theofidry/composer-inheritance-plugin": "^1.2",
-        "symfony/cache": "^5.4 || ^6.0"
+        "symfony/cache": "*"
     },
     "config": {
         "bin-dir": "bin",

--- a/vendor-bin/doctrine_mongodb/composer.json
+++ b/vendor-bin/doctrine_mongodb/composer.json
@@ -1,9 +1,9 @@
 {
     "require-dev": {
-        "alcaeus/mongo-php-adapter": "^1.2",
-        "doctrine/annotations": "^1.0",
-        "doctrine/data-fixtures": "^1.2",
-        "doctrine/mongodb-odm": "^2.1.2",
+        "alcaeus/mongo-php-adapter": "*",
+        "doctrine/annotations": "*",
+        "doctrine/data-fixtures": "*",
+        "doctrine/mongodb-odm": "*",
         "theofidry/composer-inheritance-plugin": "^1.2"
     },
     "config": {

--- a/vendor-bin/doctrine_phpcr/composer.json
+++ b/vendor-bin/doctrine_phpcr/composer.json
@@ -1,9 +1,9 @@
 {
     "require-dev": {
-        "doctrine/annotations": "^1.0",
-        "doctrine/persistence": "^1.3.4 || ^2.0",
-        "doctrine/phpcr-odm": "^1.4",
-        "jackalope/jackalope-doctrine-dbal": "^1.2",
+        "doctrine/annotations": "*",
+        "doctrine/persistence": "*",
+        "doctrine/phpcr-odm": "*",
+        "jackalope/jackalope-doctrine-dbal": "*",
         "symfony/console": "^4.4.32 || ^5.4 || ^6.0",
         "theofidry/composer-inheritance-plugin": "^1.2"
     },

--- a/vendor-bin/eloquent/composer.json
+++ b/vendor-bin/eloquent/composer.json
@@ -5,8 +5,8 @@
         ]
     },
     "require-dev": {
-        "illuminate/database": "^8.12",
-        "illuminate/filesystem": "^8.12",
+        "illuminate/database": "*",
+        "illuminate/filesystem": "*",
         "theofidry/composer-inheritance-plugin": "^1.2"
     },
     "config": {

--- a/vendor-bin/proxy-manager/composer.json
+++ b/vendor-bin/proxy-manager/composer.json
@@ -5,20 +5,20 @@
         ]
     },
     "require-dev": {
-        "alcaeus/mongo-php-adapter": "^1.2.1",
-        "doctrine/annotations": "^1.0",
-        "doctrine/data-fixtures": "^1.5.1",
-        "doctrine/doctrine-bundle": "^2.4.3",
-        "doctrine/mongodb-odm": "^2.2.2",
-        "doctrine/mongodb-odm-bundle": "^4.3.0",
-        "doctrine/orm": "^2.10.1",
-        "doctrine/phpcr-bundle": "^2.3.0",
-        "doctrine/phpcr-odm": "^1.5.4",
-        "jackalope/jackalope-doctrine-dbal": "^1.7.1",
-        "ocramius/proxy-manager": "^2.13",
+        "alcaeus/mongo-php-adapter": "*",
+        "doctrine/annotations": "*",
+        "doctrine/data-fixtures": "*",
+        "doctrine/doctrine-bundle": "*",
+        "doctrine/mongodb-odm": "*",
+        "doctrine/mongodb-odm-bundle": "*",
+        "doctrine/orm": "*",
+        "doctrine/phpcr-bundle": "*",
+        "doctrine/phpcr-odm": "*",
+        "jackalope/jackalope-doctrine-dbal": "*",
+        "ocramius/proxy-manager": "*",
         "symfony/symfony": "^4.4.32 || ^5.4 || ^6.0",
         "theofidry/composer-inheritance-plugin": "^1.2",
-        "wouterj/eloquent-bundle": "^2.1.1"
+        "wouterj/eloquent-bundle": "*"
     },
     "config": {
         "bin-dir": "bin",

--- a/vendor-bin/symfony/composer.json
+++ b/vendor-bin/symfony/composer.json
@@ -8,20 +8,20 @@
         "symfony/doctrine-messenger": "^4.4 || ^5.4 || ^6.0"
     },
     "require-dev": {
-        "alcaeus/mongo-php-adapter": "^1.2.1",
-        "doctrine/annotations": "^1.0",
-        "doctrine/data-fixtures": "^1.5.1",
-        "doctrine/doctrine-bundle": "^2.4.3",
-        "doctrine/mongodb-odm": "^2.2.2",
-        "doctrine/mongodb-odm-bundle": "^4.3.0",
-        "doctrine/orm": "^2.10.1",
-        "doctrine/phpcr-bundle": "^2.3.0",
-        "doctrine/phpcr-odm": "^1.5.4",
-        "jackalope/jackalope-doctrine-dbal": "^1.7.1",
-        "monolog/monolog": "^3.1",
+        "alcaeus/mongo-php-adapter": "*",
+        "doctrine/annotations": "*",
+        "doctrine/data-fixtures": "*",
+        "doctrine/doctrine-bundle": "*",
+        "doctrine/mongodb-odm": "*",
+        "doctrine/mongodb-odm-bundle": "*",
+        "doctrine/orm": "*",
+        "doctrine/phpcr-bundle": "*",
+        "doctrine/phpcr-odm": "*",
+        "jackalope/jackalope-doctrine-dbal": "*",
+        "monolog/monolog": "*",
         "symfony/symfony": "^4.4.32 || ^5.4 || ^6.0",
         "theofidry/composer-inheritance-plugin": "^1.2",
-        "wouterj/eloquent-bundle": "^2.1.1"
+        "wouterj/eloquent-bundle": "*"
     },
     "config": {
         "bin-dir": "bin",


### PR DESCRIPTION
In those bridges we are interested in testing the different ranges. The packages included should not be constraint, or rather only be constrainted by the root `composer.json`. Indeed if we want to test the root `conflict` section, the included package in the bridge should not have a boundary.