### PR TITLE
ci: Change the job name

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ env:
 
 jobs:
     tests:
-        name: PHP ${{ matrix.php-version }} + ${{ matrix.dependencies }} + ${{ matrix.variant }} for ${{ matrix.make-test }}
+        name: '${{ matrix.make-test }}: PHP ${{ matrix.php-version }} + ${{ matrix.dependencies }} + ${{ matrix.variant }}'
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false


### PR DESCRIPTION
Change the job name in order to group them by test first, then their respective variants. Hopefully this change brings more visibility about what is failing for a given test.