### PR TITLE
ci: Add tests for PHP 8.3

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,6 +24,7 @@ jobs:
             matrix:
                 php-version:
                     - '8.2'
+                    - '8.3'
                 dependencies: [ highest, lowest ]
                 make-test:
                     - test_core


### PR DESCRIPTION
Currently blocked by PHPUnit Bridge and Prophecy.