### PR TITLE
fix: clear entity persister on restoring class metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,6 @@ vendor-bin/doctrine/composer.lock: vendor-bin/doctrine/composer.json
 	@echo vendor-bin/doctrine/composer.lock is not up to date.
 
 vendor-bin/doctrine/vendor/phpunit: vendor-bin/doctrine/composer.lock
-	composer bin doctrine update $(COMPOSER_FLAGS) || true
 	composer bin doctrine update $(COMPOSER_FLAGS)
 	touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,7 @@ vendor-bin/doctrine/composer.lock: vendor-bin/doctrine/composer.json
 	@echo vendor-bin/doctrine/composer.lock is not up to date.
 
 vendor-bin/doctrine/vendor/phpunit: vendor-bin/doctrine/composer.lock
+	composer bin doctrine update $(COMPOSER_FLAGS) || true
 	composer bin doctrine update $(COMPOSER_FLAGS)
 	touch $@
 

--- a/fixtures/Bridge/Doctrine/Entity/DummyWithProperty.php
+++ b/fixtures/Bridge/Doctrine/Entity/DummyWithProperty.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fidry\AliceDataFixtures\Bridge\Doctrine\Entity;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+
+/**
+ * @Entity
+ */
+class DummyWithProperty
+{
+    /**
+     * @Id
+     *
+     * @Column(type="integer")
+     *
+     * @GeneratedValue
+     */
+    public int $id;
+
+    /**
+     * @Column(type="string", name="property", nullable=true)
+     */
+    public ?string $property = null;
+}

--- a/src/Bridge/Doctrine/Persister/ObjectManagerPersister.php
+++ b/src/Bridge/Doctrine/Persister/ObjectManagerPersister.php
@@ -102,6 +102,7 @@ class ObjectManagerPersister implements PersisterInterface
 
         foreach ($this->metadataToRestore as $metadata) {
             $metadataFactory->setMetadataFor($metadata->getName(), $metadata);
+            $this->clearUnitOfWorkPersister($metadata->getName());
         }
 
         $this->metadataToRestore = [];

--- a/tests/Bridge/Doctrine/Persister/ObjectManagerPersisterTest.php
+++ b/tests/Bridge/Doctrine/Persister/ObjectManagerPersisterTest.php
@@ -21,6 +21,7 @@ use Fidry\AliceDataFixtures\Bridge\Doctrine\Entity\DummyEmbeddable;
 use Fidry\AliceDataFixtures\Bridge\Doctrine\Entity\DummySubClass;
 use Fidry\AliceDataFixtures\Bridge\Doctrine\Entity\DummyWithEmbeddable;
 use Fidry\AliceDataFixtures\Bridge\Doctrine\Entity\DummyWithIdentifier;
+use Fidry\AliceDataFixtures\Bridge\Doctrine\Entity\DummyWithProperty;
 use Fidry\AliceDataFixtures\Bridge\Doctrine\Entity\DummyWithRelatedCascadePersist;
 use Fidry\AliceDataFixtures\Bridge\Doctrine\Entity\DummyWithRelation;
 use Fidry\AliceDataFixtures\Bridge\Doctrine\Entity\MappedSuperclassDummy;

--- a/tests/Bridge/Doctrine/Persister/ObjectManagerPersisterTest.php
+++ b/tests/Bridge/Doctrine/Persister/ObjectManagerPersisterTest.php
@@ -140,6 +140,24 @@ class ObjectManagerPersisterTest extends TestCase
         self::assertInstanceOf(DummyWithIdentifier::class, $entity);
     }
 
+    public function testClearingUnitOfWorkPersister(): void
+    {
+        $dummy = new DummyWithProperty();
+        $dummy->id = 1;
+
+        $this->persister->persist($dummy);
+        $this->persister->flush();
+
+        $dummy = new DummyWithProperty();
+        $dummy->property = 'foo';
+
+        $this->entityManager->persist($dummy);
+        $this->entityManager->flush();
+
+        $entity = $this->entityManager->getRepository(DummyWithProperty::class)->findOneBy(['property' => 'foo']);
+        self::assertInstanceOf(DummyWithProperty::class, $entity);
+    }
+
     public function testCanPersistEntitiesWithoutExplicitIdentifierSetEvenWhenExistingEntitiesHaveOne(): void
     {
         $dummy1 = new Dummy();


### PR DESCRIPTION
restoring the class metadata in the metadata factory does not restore the one doctrine has cached in the `class` property of it's persisters....

downstream this might lead to unexpected behaviour: when the id generator has been replaced with this library's `IdGenerator`, the basic entity persister does not recognise it as an id generator and treats the identity field as one which can be used for inserts in the [`BasicEntityPersister::getInsertColumnList`](https://github.com/doctrine/orm/blob/94144e122779098c156098fc9bb6791e53192086/src/Persisters/Entity/BasicEntityPersister.php#L1443-L1451) method 

this can lead to `Invalid parameter number: number of bound variables does not match number of tokens` errors on subsequent inserts of the entity manager. this change will fix that