### PR TITLE
Remove usage of the deprecated base extension from HttpKernel

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/FidryAliceDataFixturesExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/FidryAliceDataFixturesExtension.php
@@ -23,9 +23,9 @@ use Nelmio\Alice\Bridge\Symfony\NelmioAliceBundle;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use WouterJ\EloquentBundle\WouterJEloquentBundle;
 
 /**


### PR DESCRIPTION
The base extension available in HttpKernel only adds support for registering some classes to be added in the cache warmer of the doctrine/annotations parser, compared to the base class of the DI component. As annotations are not supported anymore in Symfony 7, this base class has been deprecated in Symfony 7.1.
As this bundle does not rely on the extra feature, it can use the base class from DI directly.