### PR TITLE
feat: Bump min version supported by Doctrine/PHPCR to 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Supports:
 * Symfony 6.4+
 * Doctrine ORM 2.5+
 * Doctrine ODM 2.0+
-* Doctrine PHPCR 1.4+
+* Doctrine PHPCR 2.0+
 * Eloquent 8.12+
 
 

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     },
     "conflict": {
         "doctrine/orm": "<2.6.3",
+        "doctrine/phpcr-odm": "<2.0.0",
         "doctrine/dbal": "<3.0",
         "doctrine/persistence": "<2.0",
         "illuminate/database": "<8.12",

--- a/doctrine-phpcr-db-settings.php
+++ b/doctrine-phpcr-db-settings.php
@@ -10,4 +10,5 @@ return [
     'dbname' => get_param('DOCTRINE_PHPCR_DB_NAME', 'fidry_alice_data_fixtures'),
     'host' => get_param('DOCTRINE_PHPCR_DB_HOST', '127.0.0.1'),
     'port' => get_param('DOCTRINE_PHPCR_DB_PORT', 3307),
+    'charset' => get_param('DOCTRINE_PHPCR_DB_CHARSET', 'utf8mb4'),
 ];

--- a/fixtures/Bridge/Doctrine/PhpCrDocument/Dummy.php
+++ b/fixtures/Bridge/Doctrine/PhpCrDocument/Dummy.php
@@ -13,16 +13,12 @@ declare(strict_types=1);
 
 namespace Fidry\AliceDataFixtures\Bridge\Doctrine\PhpCrDocument;
 
-use Doctrine\ODM\PHPCR\Mapping\Annotations\Document;
-use Doctrine\ODM\PHPCR\Mapping\Annotations\Id;
+use Doctrine\ODM\PHPCR\Mapping\Attributes\Document;
+use Doctrine\ODM\PHPCR\Mapping\Attributes\Id;
 
-/**
- * @Document()
- */
+#[Document]
 class Dummy
 {
-    /**
-     * @Id()
-     */
+    #[Id]
     public $id;
 }

--- a/fixtures/Bridge/Doctrine/PhpCrDocument/DummySubClass.php
+++ b/fixtures/Bridge/Doctrine/PhpCrDocument/DummySubClass.php
@@ -13,11 +13,9 @@ declare(strict_types=1);
 
 namespace Fidry\AliceDataFixtures\Bridge\Doctrine\PhpCrDocument;
 
-use Doctrine\ODM\PHPCR\Mapping\Annotations\Document;
+use Doctrine\ODM\PHPCR\Mapping\Attributes\Document;
 
-/**
- * @Document()
- */
+#[Document]
 class DummySubClass extends MappedSuperclassDummy
 {
 }

--- a/fixtures/Bridge/Doctrine/PhpCrDocument/MappedSuperclassDummy.php
+++ b/fixtures/Bridge/Doctrine/PhpCrDocument/MappedSuperclassDummy.php
@@ -13,22 +13,16 @@ declare(strict_types=1);
 
 namespace Fidry\AliceDataFixtures\Bridge\Doctrine\PhpCrDocument;
 
-use Doctrine\ODM\PHPCR\Mapping\Annotations\Field;
-use Doctrine\ODM\PHPCR\Mapping\Annotations\Id;
-use Doctrine\ODM\PHPCR\Mapping\Annotations\MappedSuperclass;
+use Doctrine\ODM\PHPCR\Mapping\Attributes\Field;
+use Doctrine\ODM\PHPCR\Mapping\Attributes\Id;
+use Doctrine\ODM\PHPCR\Mapping\Attributes\MappedSuperclass;
 
-/**
- * @MappedSuperclass()
- */
+#[MappedSuperclass]
 class MappedSuperclassDummy
 {
-    /**
-     * @Id()
-     */
+    #[Id]
     public $id;
 
-    /**
-     * @Field(type="string")
-     */
+    #[Field(type: 'string')]
     public string $status;
 }

--- a/tests/Bridge/DoctrinePhpCr/autoload.php
+++ b/tests/Bridge/DoctrinePhpCr/autoload.php
@@ -15,11 +15,10 @@ const ROOT = __DIR__.'/../../..';
 
 $autoload = ROOT.'/vendor-bin/doctrine_phpcr/vendor/autoload.php';
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\ODM\PHPCR\Configuration;
 use Doctrine\ODM\PHPCR\DocumentManager;
-use Doctrine\ODM\PHPCR\Mapping\Driver\AnnotationDriver;
+use Doctrine\ODM\PHPCR\Mapping\Driver\AttributeDriver;
 use Jackalope\RepositoryFactoryDoctrineDBAL;
 use PHPCR\SessionInterface;
 use PHPCR\SimpleCredentials;
@@ -42,8 +41,7 @@ $documentManagerFactory = static function () {
     })();
 
     $config = (static function (): Configuration {
-        $driver = new AnnotationDriver(
-            new AnnotationReader(),
+        $driver = new AttributeDriver(
             [
                 ROOT.'/vendor-bin/doctrine_phpcr/vendor/doctrine/phpcr-odm/lib/Doctrine/ODM/PHPCR/Document',
                 ROOT.'/fixtures/Bridge/Doctrine/PhpCrDocument',


### PR DESCRIPTION
Seeing how little changes in the tests the library is still compatible with 1.x so it should not require any changes. However for executing the tests, to ligthen the burden on this library, I am migrating to 2.0 minimum which removes support for annotations in favour of attributes.