### PR TITLE
Fix code base for support php 8.4

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,6 +24,7 @@ jobs:
             matrix:
                 php-version:
                     - '8.3'
+                    - '8.4'
                 dependencies: [ highest, lowest ]
                 make-test:
                     - test_core

--- a/doc/advanced-usage.md
+++ b/doc/advanced-usage.md
@@ -114,7 +114,7 @@ use Nelmio\Alice\IsAServiceTrait;
     private $manager;
     private $purger;
 
-    public function __construct(ObjectManager $manager, PurgeMode $purgeMode = null)
+    public function __construct(ObjectManager $manager, ?PurgeMode $purgeMode = null)
     {
         $this->manager = $manager;
         $this->purger = static::createPurger($manager, $purgeMode);

--- a/fixtures/Loader/FakeLoader.php
+++ b/fixtures/Loader/FakeLoader.php
@@ -21,7 +21,7 @@ class FakeLoader implements LoaderInterface
 {
     use NotCallableTrait;
 
-    public function load(array $fixturesFiles, array $parameters = [], array $objects = [], PurgeMode $purgeMode = null): array
+    public function load(array $fixturesFiles, array $parameters = [], array $objects = [], ?PurgeMode $purgeMode = null): array
     {
         $this->__call(__METHOD__, func_get_args());
     }

--- a/fixtures/Persistence/FakePurgerFactory.php
+++ b/fixtures/Persistence/FakePurgerFactory.php
@@ -19,7 +19,7 @@ class FakePurgerFactory implements PurgerFactoryInterface
 {
     use NotCallableTrait;
 
-    public function create(PurgeMode $mode, PurgerInterface $purger = null): PurgerInterface
+    public function create(PurgeMode $mode, ?PurgerInterface $purger = null): PurgerInterface
     {
         $this->__call(__METHOD__, func_get_args());
     }

--- a/src/Bridge/Doctrine/Purger/Purger.php
+++ b/src/Bridge/Doctrine/Purger/Purger.php
@@ -44,7 +44,7 @@ use Nelmio\Alice\IsAServiceTrait;
     private ?PurgeMode $purgeMode;
     private DoctrinePurgerInterface $purger;
 
-    public function __construct(ObjectManager $manager, PurgeMode $purgeMode = null)
+    public function __construct(ObjectManager $manager, ?PurgeMode $purgeMode = null)
     {
         $this->manager = $manager;
         $this->purgeMode = $purgeMode;
@@ -52,7 +52,7 @@ use Nelmio\Alice\IsAServiceTrait;
         $this->purger = static::createPurger($manager, $purgeMode);
     }
 
-    public function create(PurgeMode $mode, PurgerInterface $purger = null): PurgerInterface
+    public function create(PurgeMode $mode, ?PurgerInterface $purger = null): PurgerInterface
     {
         if (null === $purger) {
             return new self($this->manager, $mode);

--- a/src/Bridge/Eloquent/Purger/ModelPurger.php
+++ b/src/Bridge/Eloquent/Purger/ModelPurger.php
@@ -39,7 +39,7 @@ use Nelmio\Alice\IsAServiceTrait;
         $this->repository = $repository;
     }
 
-    public function create(PurgeMode $mode, PurgerInterface $purger = null): PurgerInterface
+    public function create(PurgeMode $mode, ?PurgerInterface $purger = null): PurgerInterface
     {
         if (PurgeMode::createTruncateMode() == $mode) {
             throw new InvalidArgumentException(

--- a/src/Exception/MaxPassReachedException.php
+++ b/src/Exception/MaxPassReachedException.php
@@ -31,7 +31,7 @@ class MaxPassReachedException extends RuntimeException implements LoadingThrowab
     private array $stack = [];
 
     #[Pure]
-    public function __construct($message, $code = 0, Throwable $previous = null, ErrorTracker $errorTracker = null)
+    public function __construct($message, $code = 0, Throwable $previous = null, ?ErrorTracker $errorTracker = null)
     {
         parent::__construct($message, $code, $previous);
 
@@ -53,7 +53,7 @@ class MaxPassReachedException extends RuntimeException implements LoadingThrowab
         FileTracker $fileTracker,
         ErrorTracker $errorTracker,
         int $code = 0,
-        Throwable $previous = null
+        ?Throwable $previous = null
     ) {
         return new static(
             static::createMessage($limit, $fileTracker, $errorTracker),

--- a/src/Exception/MaxPassReachedException.php
+++ b/src/Exception/MaxPassReachedException.php
@@ -31,7 +31,7 @@ class MaxPassReachedException extends RuntimeException implements LoadingThrowab
     private array $stack = [];
 
     #[Pure]
-    public function __construct($message, $code = 0, Throwable $previous = null, ?ErrorTracker $errorTracker = null)
+    public function __construct($message, $code = 0, ?Throwable $previous = null, ?ErrorTracker $errorTracker = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/src/Loader/FileResolverLoader.php
+++ b/src/Loader/FileResolverLoader.php
@@ -40,7 +40,7 @@ use Psr\Log\NullLogger;
     public function __construct(
         LoaderInterface $decoratedLoader,
         FileResolverInterface $fileResolver,
-        LoggerInterface $logger = null
+        ?LoggerInterface $logger = null
     ) {
         $this->loader = $decoratedLoader;
         $this->fileResolver = $fileResolver;
@@ -63,7 +63,7 @@ use Psr\Log\NullLogger;
      *
      * {@inheritdoc}
      */
-    public function load(array $fixturesFiles, array $parameters = [], array $objects = [], PurgeMode $purgeMode = null): array
+    public function load(array $fixturesFiles, array $parameters = [], array $objects = [], ?PurgeMode $purgeMode = null): array
     {
         $this->logger->info('Resolving fixture files.');
 

--- a/src/Loader/MultiPassLoader.php
+++ b/src/Loader/MultiPassLoader.php
@@ -63,7 +63,7 @@ use Nelmio\Alice\Throwable\Exception\Generator\Resolver\UnresolvableValueDuringG
      *
      * @throws MaxPassReachedException
      */
-    public function load(array $fixturesFiles, array $parameters = [], array $objects = [], PurgeMode $purgeMode = null): array
+    public function load(array $fixturesFiles, array $parameters = [], array $objects = [], ?PurgeMode $purgeMode = null): array
     {
         $errorTracker = new ErrorTracker();
         $filesTracker = new FileTracker(...$fixturesFiles);

--- a/src/Loader/PersisterLoader.php
+++ b/src/Loader/PersisterLoader.php
@@ -74,7 +74,7 @@ use Psr\Log\NullLogger;
      *
      * {@inheritdoc}
      */
-    public function load(array $fixturesFiles, array $parameters = [], array $objects = [], PurgeMode $purgeMode = null): array
+    public function load(array $fixturesFiles, array $parameters = [], array $objects = [], ?PurgeMode $purgeMode = null): array
     {
         $objects = $this->loader->load($fixturesFiles, $parameters, $objects, $purgeMode);
 

--- a/src/Loader/PersisterLoader.php
+++ b/src/Loader/PersisterLoader.php
@@ -47,7 +47,7 @@ use Psr\Log\NullLogger;
     public function __construct(
         LoaderInterface $decoratedLoader,
         PersisterInterface $persister,
-        LoggerInterface $logger = null,
+        ?LoggerInterface $logger = null,
         array $processors = []
     ) {
         $this->loader = $decoratedLoader;

--- a/src/Loader/PurgerLoader.php
+++ b/src/Loader/PurgerLoader.php
@@ -46,7 +46,7 @@ use Psr\Log\NullLogger;
         LoaderInterface $decoratedLoader,
         PurgerFactoryInterface $purgerFactory,
         string $defaultPurgeMode,
-        LoggerInterface $logger = null
+        ?LoggerInterface $logger = null
     ) {
         if (!isset(self::$PURGE_MAPPING)) {
             self::$PURGE_MAPPING = [
@@ -98,7 +98,7 @@ use Psr\Log\NullLogger;
      *
      * {@inheritdoc}
      */
-    public function load(array $fixturesFiles, array $parameters = [], array $objects = [], PurgeMode $purgeMode = null): array
+    public function load(array $fixturesFiles, array $parameters = [], array $objects = [], ?PurgeMode $purgeMode = null): array
     {
         if (null === $purgeMode) {
             $purgeMode = $this->defaultPurgeMode;

--- a/src/Loader/SimpleLoader.php
+++ b/src/Loader/SimpleLoader.php
@@ -37,7 +37,7 @@ use Psr\Log\NullLogger;
     private LoggerInterface $logger;
 
     #[Pure]
-    public function __construct(FilesLoaderInterface $fileLoader, LoggerInterface $logger = null)
+    public function __construct(FilesLoaderInterface $fileLoader, ?LoggerInterface $logger = null)
     {
         $this->filesLoader = $fileLoader;
         $this->logger = $logger ?? new NullLogger();
@@ -48,7 +48,7 @@ use Psr\Log\NullLogger;
      *
      * {@inheritdoc}
      */
-    public function load(array $fixturesFiles, array $parameters = [], array $objects = [], PurgeMode $purgeMode = null): array
+    public function load(array $fixturesFiles, array $parameters = [], array $objects = [], ?PurgeMode $purgeMode = null): array
     {
         $this->logger->info('Loading fixtures.');
 

--- a/src/LoaderInterface.php
+++ b/src/LoaderInterface.php
@@ -24,5 +24,5 @@ interface LoaderInterface
      *
      * @return object[]
      */
-    public function load(array $fixturesFiles, array $parameters = [], array $objects = [], PurgeMode $purgeMode = null): array;
+    public function load(array $fixturesFiles, array $parameters = [], array $objects = [], ?PurgeMode $purgeMode = null): array;
 }

--- a/src/Persistence/PurgerFactoryInterface.php
+++ b/src/Persistence/PurgerFactoryInterface.php
@@ -19,5 +19,5 @@ interface PurgerFactoryInterface
      * Creates a new purger with the given purger mode. As the purger is stateful, it may be useful sometimes to create
      * a new purger with the same state as an existing one and just have control on the purge mode.
      */
-    public function create(PurgeMode $mode, PurgerInterface $purger = null): PurgerInterface;
+    public function create(PurgeMode $mode, ?PurgerInterface $purger = null): PurgerInterface;
 }

--- a/tests/Loader/MultiPassFileLoaderTest.php
+++ b/tests/Loader/MultiPassFileLoaderTest.php
@@ -53,7 +53,7 @@ class MultiPassFileLoaderTest extends TestCase
     /**
      * @dataProvider provideMaxPassValue
      */
-    public function testMaxPassGivenMustBeAStrictlyPositiveInteger(int $maxPass, string $expectedExceptionMessage = null): void
+    public function testMaxPassGivenMustBeAStrictlyPositiveInteger(int $maxPass, ?string $expectedExceptionMessage = null): void
     {
         try {
             new MultiPassLoader(new FakeFileLoader(), $maxPass);


### PR DESCRIPTION
https://www.php.net/ChangeLog-8.php
https://www.php.net/releases/8.4/en.php

`Implicitly nullable parameter types are now deprecated.`