### PR TITLE
Fix for doctrine 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "theofidry/alice-data-fixtures",
+    "name": "drewblin/alice-data-fixtures",
     "description": "Nelmio alice extension to persist the loaded fixtures.",
     "keywords": [
         "Fixture",
@@ -31,6 +31,9 @@
         "phpspec/prophecy-phpunit": "^2.0.1",
         "phpunit/phpunit": "^9.5.10",
         "symfony/phpunit-bridge": "^5.3.8 || ^6.4"
+    },
+    "replace": {
+        "theofidry/alice-data-fixtures": "1.7.2"
     },
     "conflict": {
         "doctrine/orm": "<2.6.3",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "drewblin/alice-data-fixtures",
+    "name": "theofidry/alice-data-fixtures",
     "description": "Nelmio alice extension to persist the loaded fixtures.",
     "keywords": [
         "Fixture",
@@ -31,9 +31,6 @@
         "phpspec/prophecy-phpunit": "^2.0.1",
         "phpunit/phpunit": "^9.5.10",
         "symfony/phpunit-bridge": "^5.3.8 || ^6.4"
-    },
-    "replace": {
-        "theofidry/alice-data-fixtures": "1.7.2"
     },
     "conflict": {
         "doctrine/orm": "<2.6.3",

--- a/src/Bridge/Doctrine/IdGenerator.php
+++ b/src/Bridge/Doctrine/IdGenerator.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Fidry\AliceDataFixtures\Bridge\Doctrine;
 
 use function count;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Id\AbstractIdGenerator;
 use function get_class;
 use function is_array;

--- a/src/Bridge/Doctrine/IdGenerator.php
+++ b/src/Bridge/Doctrine/IdGenerator.php
@@ -45,7 +45,7 @@ class IdGenerator extends AbstractIdGenerator
             return reset($idValues);
         }
 
-        return $this->decorated->generate($em, $entity);
+        return $this->decorated->generateId($em, $entity);
     }
 
     public function isPostInsertGenerator(): bool

--- a/src/Bridge/Doctrine/IdGenerator.php
+++ b/src/Bridge/Doctrine/IdGenerator.php
@@ -32,7 +32,7 @@ class IdGenerator extends AbstractIdGenerator
         $this->decorated = $decorated;
     }
 
-    public function generate(EntityManager $em, $entity): mixed
+    public function generateId(EntityManagerInterface $em, object|null $entity): mixed
     {
         Assert::notNull($entity);
 

--- a/src/Bridge/Doctrine/Persister/ObjectManagerPersister.php
+++ b/src/Bridge/Doctrine/Persister/ObjectManagerPersister.php
@@ -144,11 +144,7 @@ class ObjectManagerPersister implements PersisterInterface
         $this->objectChecked[$objectId] = true;
 
         foreach ($metadata->getAssociationMappings() as $fieldName => $associationMapping) {
-            if (!array_key_exists('targetEntity', $associationMapping)) {
-                continue;
-            }
-
-            $targetEntityClassName = $associationMapping['targetEntity'];
+            $targetEntityClassName = $associationMapping->targetEntity;
             $fieldValueOrFieldValues = $metadata->getFieldValue($object, $fieldName);
 
             if (is_array($fieldValueOrFieldValues)) {

--- a/src/Bridge/Doctrine/Persister/ObjectManagerPersister.php
+++ b/src/Bridge/Doctrine/Persister/ObjectManagerPersister.php
@@ -22,7 +22,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as ODMClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata as PHPCRClassMetadata;
 use Doctrine\ORM\EntityManagerInterface as ORMEntityManager;
 use Doctrine\ORM\Id\AssignedGenerator as ORMAssignedGenerator;
-use Doctrine\ORM\Mapping\ClassMetadataInfo as ORMClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Persistence\Mapping\ClassMetadata;
@@ -113,7 +113,7 @@ class ObjectManagerPersister implements PersisterInterface
     {
         $metadata = $this->objectManager->getClassMetadata($className);
 
-        if (!($metadata instanceof ORMClassMetadataInfo)) {
+        if (!($metadata instanceof ORMClassMetadata)) {
             return $metadata;
         }
 
@@ -133,7 +133,7 @@ class ObjectManagerPersister implements PersisterInterface
         return $metadata;
     }
 
-    private function checkAssociationsMetadata(ORMClassMetadataInfo $metadata, object $object): void
+    private function checkAssociationsMetadata(ORMClassMetadata $metadata, object $object): void
     {
         $objectId = spl_object_id($object);
 
@@ -191,13 +191,13 @@ class ObjectManagerPersister implements PersisterInterface
     private static function isClassMetadataOfPersistableClass(ClassMetadata $metadata): bool
     {
         $isMappedSuperClass = (
-            $metadata instanceof ORMClassMetadataInfo
+            $metadata instanceof ORMClassMetadata
                 || $metadata instanceof ODMClassMetadata
                 || $metadata instanceof PHPCRClassMetadata
         )
             && $metadata->isMappedSuperclass;
 
-        $isEmbeddedClass = $metadata instanceof ORMClassMetadataInfo
+        $isEmbeddedClass = $metadata instanceof ORMClassMetadata
             && $metadata->isEmbeddedClass;
 
         return !($isMappedSuperClass || $isEmbeddedClass);
@@ -215,8 +215,8 @@ class ObjectManagerPersister implements PersisterInterface
     }
 
     private function configureIdGenerator(
-        ORMClassMetadataInfo $metadata
-    ): ORMClassMetadataInfo {
+        ORMClassMetadata $metadata
+    ): ORMClassMetadata {
         $this->saveMetadataToRestore($metadata);
 
         $newMetadata = clone $metadata;


### PR DESCRIPTION
Docrine ORM 3.0 has such BC-break changes:
* Signature of AbstractIdGenerator changed
* ClassMetadataInfo was removed
* $metadata->getAssociationMappings() returns object instead of array

Note, changes in this pull request are incompatible with Doctrine ORM 2.0. So, I'm not sure this corresponds to you vision of project. But you can use this PR to understand what code should be fixed.