### PR TITLE
fix: Tighten the Doctrine ORM dependency conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "webmozart/assert": "^1.10"
     },
     "require-dev": {
-        "doctrine/annotations": "^1.13",
         "bamarni/composer-bin-plugin": "^1.4.1",
         "phpspec/prophecy": "^1.14.0",
         "phpspec/prophecy-phpunit": "^2.0.1",
@@ -34,7 +33,7 @@
     },
     "conflict": {
         "doctrine/data-fixtures": "<1.7.0",
-        "doctrine/orm": "<2.20",
+        "doctrine/orm": "<2.20 || >=3.0",
         "doctrine/doctrine-bundle": "<2.11.0",
         "doctrine/mongodb-odm-bundle": "<5.1.0",
         "doctrine/mongodb-odm": "<2.6.0",


### PR DESCRIPTION
Currently this libraries allows Doctrine ORM 3 despite not being compatible with it. It was not causing an issue locally due to `doctrine/annotations`.