### PR TITLE
perf: Do not do an unnecessary metadata lookup

### DIFF
--- a/src/Bridge/Doctrine/Persister/ObjectManagerPersister.php
+++ b/src/Bridge/Doctrine/Persister/ObjectManagerPersister.php
@@ -75,11 +75,11 @@ class ObjectManagerPersister implements PersisterInterface
         $className = $object::class;
 
         if (isset($this->persistableClasses[$className])) {
-            $metadata = $this->getMetadata($className, $object);
-
             try {
                 $this->objectManager->persist($object);
             } catch (ORMException $exception) {
+                $metadata = $this->getMetadata($className, $object);
+
                 if ($metadata->idGenerator instanceof ORMAssignedGenerator) {
                     throw ObjectGeneratorPersisterExceptionFactory::createForEntityMissingAssignedIdForField($object);
                 }


### PR DESCRIPTION
The metadata object is only used in the `catch()` block hence there is no need to do it before the `try` block. It may not have had much relevance back when it was a tiny call, but now it does a lot more and is relatively expensive.

Related to #313.